### PR TITLE
Add portal invite option and subsection navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,129 @@
+(function () {
+    const navToggle = document.getElementById('mobileNavToggle');
+    const nav = document.getElementById('primaryNav');
+
+    if (navToggle && nav) {
+        navToggle.addEventListener('click', () => {
+            nav.classList.toggle('open');
+        });
+    }
+
+    const tabs = document.querySelectorAll('.tab');
+    if (tabs.length) {
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                tabs.forEach((button) => button.classList.remove('active'));
+                tab.classList.add('active');
+            });
+        });
+    }
+
+    const accordionTriggers = document.querySelectorAll('.accordion-trigger');
+    if (accordionTriggers.length) {
+        accordionTriggers.forEach((trigger) => {
+            const targetId = trigger.getAttribute('data-accordion-target');
+            const content = targetId ? document.getElementById(targetId) : null;
+            if (!content) return;
+
+            if (content.dataset.open === 'true') {
+                content.style.maxHeight = content.scrollHeight + 'px';
+            }
+
+            trigger.addEventListener('click', () => {
+                const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+                trigger.setAttribute('aria-expanded', String(!isExpanded));
+
+                if (!isExpanded) {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                } else {
+                    content.style.maxHeight = '0px';
+                }
+            });
+        });
+    }
+
+    const subsectionElements = Array.from(document.querySelectorAll('[data-subsection]'));
+    if (subsectionElements.length > 1) {
+        const pageContent = document.querySelector('.page-content');
+        const header = pageContent ? pageContent.querySelector('.page-header') : null;
+        const sectionToButton = new Map();
+
+        function showSection(sectionToShow) {
+            subsectionElements.forEach((section) => {
+                section.classList.add('is-hidden');
+            });
+
+            sectionToShow.classList.remove('is-hidden');
+
+            sectionToButton.forEach((button, section) => {
+                if (section === sectionToShow) {
+                    button.classList.add('is-active');
+                } else {
+                    button.classList.remove('is-active');
+                }
+            });
+
+            const parent = sectionToShow.parentElement;
+            if (parent && parent.classList.contains('split-layout')) {
+                Array.from(parent.children).forEach((child) => {
+                    if (child.hasAttribute('data-subsection') && child !== sectionToShow) {
+                        child.classList.add('is-hidden');
+                    }
+                });
+            }
+
+            sectionToShow.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+
+        const navWrapper = document.createElement('div');
+        navWrapper.className = 'subsection-nav';
+
+        subsectionElements.forEach((section, index) => {
+            if (!section.id) {
+                section.id = `section-${index + 1}`;
+            }
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'subsection-nav__button';
+            button.textContent = section.dataset.subsection || `Section ${index + 1}`;
+            button.setAttribute('aria-controls', section.id);
+
+            if (index === 0) {
+                button.classList.add('is-active');
+            } else {
+                section.classList.add('is-hidden');
+            }
+
+            button.addEventListener('click', () => {
+                showSection(section);
+            });
+
+            navWrapper.appendChild(button);
+            sectionToButton.set(section, button);
+        });
+
+        if (header && navWrapper.childElementCount) {
+            header.insertAdjacentElement('afterend', navWrapper);
+        } else if (pageContent) {
+            pageContent.insertAdjacentElement('afterbegin', navWrapper);
+        }
+
+        document.querySelectorAll('[data-subsection-target]').forEach((trigger) => {
+            trigger.addEventListener('click', (event) => {
+                const targetId = trigger.getAttribute('data-subsection-target');
+                if (!targetId) {
+                    return;
+                }
+
+                const targetSection = document.getElementById(targetId);
+                if (!targetSection || !sectionToButton.has(targetSection)) {
+                    return;
+                }
+
+                event.preventDefault();
+                showSection(targetSection);
+            });
+        });
+    }
+})();

--- a/calendar.html
+++ b/calendar.html
@@ -47,7 +47,7 @@
             </div>
         </section>
 
-        <section class="content-card">
+        <section id="calendar-overview" class="content-card" data-subsection="Monthly overview">
             <div class="card-header">
                 <div>
                     <h2 class="card-title">October 2025 overview</h2>
@@ -161,7 +161,7 @@
         </section>
 
         <section class="split-layout">
-            <article class="content-card">
+            <article id="prep-checklist" class="content-card" data-subsection="Prep checklist">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Prep checklist</h2>
@@ -176,7 +176,7 @@
                 </div>
             </article>
 
-            <article class="content-card">
+            <article id="week-glance" class="content-card" data-subsection="Week at a glance">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Week at a glance</h2>
@@ -221,15 +221,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/employees.html
+++ b/employees.html
@@ -30,7 +30,7 @@
                 <a class="nav-link" href="settings.html">Settings</a>
             </nav>
 
-            <a class="cta-button" href="#add-employee">+ Add Team Member</a>
+            <a class="cta-button" href="#add-employee" data-subsection-target="add-employee">+ Add Team Member</a>
         </div>
     </header>
 
@@ -42,12 +42,12 @@
                 <p class="lead-text">Track availability, assign shifts, and empower your crew to deliver world-class service.</p>
             </div>
             <div class="hero-actions">
-                <a class="button primary" href="#add-employee">Invite teammate</a>
+                <a class="button primary" href="#add-employee" data-subsection-target="add-employee">Add teammate</a>
                 <a class="secondary-link" href="events.html">Match to events →</a>
             </div>
         </section>
 
-        <section class="card-grid stats-grid">
+        <section id="team-snapshot" class="card-grid stats-grid" data-subsection="Team snapshot">
             <article class="stat-card">
                 <span class="stat-card__label">Active staff</span>
                 <span class="stat-card__value">14</span>
@@ -65,7 +65,7 @@
             </article>
         </section>
 
-        <section class="content-card">
+        <section id="team-directory" class="content-card" data-subsection="Team directory">
             <div class="card-header">
                 <div>
                     <h2 class="card-title">Team directory</h2>
@@ -107,7 +107,7 @@
         </section>
 
         <section class="split-layout">
-            <article class="content-card">
+            <article id="upcoming-shifts" class="content-card" data-subsection="Upcoming shifts">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Upcoming shifts</h2>
@@ -149,14 +149,15 @@
                 </div>
             </article>
 
-            <article id="add-employee" class="content-card">
+            <article id="add-employee" class="content-card" data-subsection="Add team member">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Add team member</h2>
-                        <p class="card-subtitle">Invite freelancers or seasonal staff to upcoming shifts.</p>
+                        <p class="card-subtitle">Add new hires instantly and optionally invite them to the portal.</p>
                     </div>
                 </div>
                 <form>
+                    <p class="form-helper-text">Team members are added to your roster immediately. Check the box below if you'd like to send them a portal invite so they can review shifts, pay, and resources.</p>
                     <div class="form-grid">
                         <div class="form-field">
                             <label for="teamName">Name</label>
@@ -185,9 +186,15 @@
                         <label for="teamNotes">Specialties & certifications</label>
                         <textarea id="teamNotes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
                     </div>
+                    <div class="form-field">
+                        <label class="checkbox-field" for="sendPortalInvite">
+                            <input id="sendPortalInvite" type="checkbox" />
+                            Send portal invite so they can view shifts and pay updates
+                        </label>
+                    </div>
                     <div class="table-actions" style="justify-content: flex-end;">
                         <button class="button ghost" type="reset">Clear</button>
-                        <button class="button primary" type="submit">Invite</button>
+                        <button class="button primary" type="submit">Add team member</button>
                     </div>
                 </form>
             </article>
@@ -196,15 +203,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -42,12 +42,12 @@
                 <p class="lead-text">Glance through every celebration, from contracted events to pending tastings, and manage staffing in one place.</p>
             </div>
             <div class="hero-actions">
-                <a class="button primary" href="#new-event">Log new booking</a>
+                <a class="button primary" href="#new-event" data-subsection-target="new-event">Log new booking</a>
                 <a class="secondary-link" href="calendar.html">Sync with calendar →</a>
             </div>
         </section>
 
-        <section class="content-card">
+        <section id="event-pipeline" class="content-card" data-subsection="Event pipeline">
             <div class="card-header">
                 <div>
                     <h2 class="card-title">Event pipeline</h2>
@@ -127,7 +127,7 @@
             </div>
         </section>
 
-        <section id="new-event" class="content-card">
+        <section id="new-event" class="content-card" data-subsection="Create new event">
             <div class="card-header">
                 <div>
                     <h2 class="card-title">Create new event</h2>
@@ -181,23 +181,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-
-        const tabs = document.querySelectorAll('.tab');
-        tabs.forEach((tab) => {
-            tab.addEventListener('click', () => {
-                tabs.forEach((button) => button.classList.remove('active'));
-                tab.classList.add('active');
-            });
-        });
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             </div>
         </section>
 
-        <section class="card-grid stats-grid">
+        <section id="dashboard-stats" class="card-grid stats-grid" data-subsection="At-a-glance">
             <article class="stat-card">
                 <span class="stat-card__label">Total events</span>
                 <span class="stat-card__value">12</span>
@@ -71,7 +71,7 @@
         </section>
 
         <section class="split-layout">
-            <article class="content-card">
+            <article id="recent-activity" class="content-card" data-subsection="Recent activity">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Recent activity</h2>
@@ -123,7 +123,7 @@
                 </div>
             </article>
 
-            <article class="content-card">
+            <article id="critical-alerts" class="content-card" data-subsection="Critical alerts">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Critical alerts</h2>
@@ -230,37 +230,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-
-        const accordionTriggers = document.querySelectorAll('.accordion-trigger');
-        accordionTriggers.forEach((trigger) => {
-            const targetId = trigger.getAttribute('data-accordion-target');
-            const content = document.getElementById(targetId);
-            if (!content) return;
-
-            if (content.dataset.open === 'true') {
-                content.style.maxHeight = content.scrollHeight + 'px';
-            }
-
-            trigger.addEventListener('click', () => {
-                const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
-                trigger.setAttribute('aria-expanded', String(!isExpanded));
-
-                if (!isExpanded) {
-                    content.style.maxHeight = content.scrollHeight + 'px';
-                } else {
-                    content.style.maxHeight = '0px';
-                }
-            });
-        });
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -42,12 +42,12 @@
                 <p class="lead-text">Update company info, adjust notifications, and align the platform with your brand.</p>
             </div>
             <div class="hero-actions">
-                <a class="button primary" href="#account-settings">Save changes</a>
+                <a class="button primary" href="#account-settings" data-subsection-target="account-settings">Save changes</a>
                 <a class="secondary-link" href="index.html">Return to dashboard →</a>
             </div>
         </section>
 
-        <section id="account-settings" class="content-card">
+        <section id="account-settings" class="content-card" data-subsection="Account preferences">
             <div class="card-header">
                 <div>
                     <h2 class="card-title">Account preferences</h2>
@@ -96,7 +96,7 @@
         </section>
 
         <section class="split-layout">
-            <article class="content-card">
+            <article id="notification-settings" class="content-card" data-subsection="Notification settings">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Notification settings</h2>
@@ -111,7 +111,7 @@
                 </div>
             </article>
 
-            <article class="content-card">
+            <article id="branding-settings" class="content-card" data-subsection="Branding">
                 <div class="card-header">
                     <div>
                         <h2 class="card-title">Branding</h2>
@@ -142,15 +142,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -542,6 +542,12 @@ textarea {
   resize: vertical;
 }
 
+.form-helper-text {
+  font-size: 0.85rem;
+  color: var(--slate-500);
+  margin-bottom: 0.5rem;
+}
+
 .preferences-list {
   display: flex;
   flex-direction: column;
@@ -593,6 +599,41 @@ textarea {
 .tab.active {
   background: rgba(37, 99, 235, 0.15);
   color: var(--primary-600);
+}
+
+.subsection-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.subsection-nav__button {
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--slate-600);
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.subsection-nav__button:hover {
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--primary-600);
+}
+
+.subsection-nav__button.is-active {
+  background: rgba(37, 99, 235, 0.22);
+  color: var(--primary-600);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 .list-grid {


### PR DESCRIPTION
## Summary
- let admins add team members immediately while optionally sending a portal invite from the employees page
- introduce a shared subsection navigation experience that hides page sections until their button is selected
- centralize page interactions into a reusable `app.js` and replace per-page inline scripts

## Testing
- No automated tests were run (static HTML site)


------
https://chatgpt.com/codex/tasks/task_e_68de14ca548883338dab1f6c93c57711