### PR TITLE
Add local storage data layer for events and employees

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -50,114 +50,11 @@
         <section class="content-card">
             <div class="card-header">
                 <div>
-                    <h2 class="card-title">October 2025 overview</h2>
+                    <h2 class="card-title" id="calendarMonthTitle">Monthly overview</h2>
                     <p class="card-subtitle">Hover over a day to reveal assignments and prep checklists.</p>
                 </div>
             </div>
-            <div class="calendar-grid">
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 1</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 2</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 3</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 4</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 5</span>
-                    <div class="calendar-event">Corporate Party</div>
-                    <p class="card-subtitle">Call time 6:00 PM · 4 staff</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 6</span>
-                    <div class="calendar-event">Tasting Prep</div>
-                    <p class="card-subtitle">Inventory pull · Syrups ready</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 7</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 8</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 9</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 10</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 11</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 12</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 13</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 14</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 15</span>
-                    <div class="calendar-event">Wedding Reception</div>
-                    <p class="card-subtitle">Needs staffing</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 16</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 17</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 18</span>
-                    <div class="calendar-event">Mixology Workshop</div>
-                    <p class="card-subtitle">Priya · Jamie · 5:30 PM</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 19</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 20</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 21</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 22</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 23</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 24</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 25</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 26</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 27</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 28</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 29</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 30</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 31</span>
-                    <div class="calendar-event">Inventory Audit</div>
-                </div>
-            </div>
+            <div class="calendar-grid" id="calendarGrid"></div>
         </section>
 
         <section class="split-layout">
@@ -193,26 +90,7 @@
                                 <th>Prep hours</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            <tr>
-                                <td>Corporate Party</td>
-                                <td>120</td>
-                                <td>4</td>
-                                <td>6</td>
-                            </tr>
-                            <tr>
-                                <td>Wedding Reception</td>
-                                <td>180</td>
-                                <td>Pending</td>
-                                <td>8</td>
-                            </tr>
-                            <tr>
-                                <td>Mixology Workshop</td>
-                                <td>25</td>
-                                <td>2</td>
-                                <td>3</td>
-                            </tr>
-                        </tbody>
+                        <tbody id="weekAtGlanceBody"></tbody>
                     </table>
                 </div>
             </article>
@@ -221,15 +99,8 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="scripts/data-store.js"></script>
+    <script src="scripts/common.js"></script>
+    <script src="scripts/calendar.js"></script>
 </body>
 </html>

--- a/employees.html
+++ b/employees.html
@@ -50,17 +50,17 @@
         <section class="card-grid stats-grid">
             <article class="stat-card">
                 <span class="stat-card__label">Active staff</span>
-                <span class="stat-card__value">14</span>
-                <span class="stat-card__meta success">10 available this week</span>
+                <span class="stat-card__value" id="activeStaffCount">0</span>
+                <span class="stat-card__meta success">0 available this week</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Roles covered</span>
-                <span class="stat-card__value" style="font-size:1.8rem;">5</span>
+                <span class="stat-card__value" id="rolesCovered" style="font-size:1.8rem;">0</span>
                 <span class="stat-card__meta">Bartenders, Mixologists, Leads…</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Upcoming PTO</span>
-                <span class="stat-card__value" style="color: var(--warning-500);">3</span>
+                <span class="stat-card__value" id="upcomingPto" style="color: var(--warning-500);">0</span>
                 <span class="stat-card__meta warning">Plan coverage</span>
             </article>
         </section>
@@ -72,38 +72,7 @@
                     <p class="card-subtitle">Search, sort, and understand everyone’s strengths at a glance.</p>
                 </div>
             </div>
-            <div class="list-grid">
-                <article class="person-card">
-                    <h3 class="person-card__name">John Doe</h3>
-                    <p class="person-card__role">Bar Lead · Flair certified</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Jane Smith</h3>
-                    <p class="person-card__role">Mixologist · Mocktail specialist</p>
-                    <div class="person-card__status"><span class="badge warning">On PTO</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Alex Rivera</h3>
-                    <p class="person-card__role">Bartender · Bilingual</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Priya Singh</h3>
-                    <p class="person-card__role">Mixology Lead · Seasonal menu</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Jamie Lee</h3>
-                    <p class="person-card__role">Support · Prep specialist</p>
-                    <div class="person-card__status"><span class="badge warning">Limited hours</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Marcus Allen</h3>
-                    <p class="person-card__role">Barback</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-            </div>
+            <div class="list-grid" id="employeeList"></div>
         </section>
 
         <section class="split-layout">
@@ -156,16 +125,16 @@
                         <p class="card-subtitle">Invite freelancers or seasonal staff to upcoming shifts.</p>
                     </div>
                 </div>
-                <form>
+                <form id="employeeForm">
                     <div class="form-grid">
                         <div class="form-field">
                             <label for="teamName">Name</label>
-                            <input id="teamName" type="text" placeholder="Full name" />
+                            <input id="teamName" name="teamName" type="text" placeholder="Full name" required />
                         </div>
                         <div class="form-field">
                             <label for="teamRole">Role</label>
-                            <select id="teamRole">
-                                <option selected disabled>Select role</option>
+                            <select id="teamRole" name="teamRole" required>
+                                <option value="" selected disabled>Select role</option>
                                 <option>Bartender</option>
                                 <option>Mixologist</option>
                                 <option>Bar Lead</option>
@@ -174,16 +143,25 @@
                         </div>
                         <div class="form-field">
                             <label for="teamEmail">Email</label>
-                            <input id="teamEmail" type="email" placeholder="name@bartending2u.com" />
+                            <input id="teamEmail" name="teamEmail" type="email" placeholder="name@bartending2u.com" />
                         </div>
                         <div class="form-field">
                             <label for="teamPhone">Phone</label>
-                            <input id="teamPhone" type="tel" placeholder="(555) 123-4567" />
+                            <input id="teamPhone" name="teamPhone" type="tel" placeholder="(555) 123-4567" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamStatus">Availability</label>
+                            <select id="teamStatus" name="teamStatus" required>
+                                <option value="Available" data-level="success" selected>Available</option>
+                                <option value="On PTO" data-level="warning">On PTO</option>
+                                <option value="Limited hours" data-level="warning">Limited hours</option>
+                                <option value="Unavailable" data-level="danger">Unavailable</option>
+                            </select>
                         </div>
                     </div>
                     <div class="form-field">
                         <label for="teamNotes">Specialties & certifications</label>
-                        <textarea id="teamNotes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
+                        <textarea id="teamNotes" name="teamNotes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
                     </div>
                     <div class="table-actions" style="justify-content: flex-end;">
                         <button class="button ghost" type="reset">Clear</button>
@@ -196,15 +174,8 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="scripts/data-store.js"></script>
+    <script src="scripts/common.js"></script>
+    <script src="scripts/employees.js"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -68,61 +68,14 @@
                             <th>Date</th>
                             <th>Location</th>
                             <th>Package</th>
+                            <th>Guests</th>
+                            <th>Payout</th>
                             <th>Status</th>
                             <th>Staffing</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <tr>
-                            <td>Corporate Party</td>
-                            <td>Oct 5, 2025</td>
-                            <td>Downtown Houston</td>
-                            <td>Signature Cocktail Bar</td>
-                            <td><span class="badge success">Confirmed</span></td>
-                            <td><span class="badge success">Fully staffed</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">View</a>
-                                <a class="card-action" href="#">Staff</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Wedding Reception</td>
-                            <td>Oct 15, 2025</td>
-                            <td>The Grand Hall</td>
-                            <td>Premium Mixology</td>
-                            <td><span class="badge warning">Awaiting deposit</span></td>
-                            <td><span class="badge warning">Needs 2 bartenders</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Send reminder</a>
-                                <a class="card-action" href="#">Assign</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Holiday Gala</td>
-                            <td>Nov 30, 2025</td>
-                            <td>Skyline Ballroom</td>
-                            <td>Craft Experience</td>
-                            <td><span class="badge danger">Contract overdue</span></td>
-                            <td><span class="badge warning">Partial coverage</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Follow up</a>
-                                <a class="card-action" href="#">View notes</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Mixology Workshop</td>
-                            <td>Dec 3, 2025</td>
-                            <td>Private Residence</td>
-                            <td>Interactive Class</td>
-                            <td><span class="badge success">Confirmed</span></td>
-                            <td><span class="badge success">Ready</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Checklist</a>
-                                <a class="card-action" href="#">Prep sheet</a>
-                            </td>
-                        </tr>
-                    </tbody>
+                    <tbody id="eventsTableBody"></tbody>
                 </table>
             </div>
         </section>
@@ -134,28 +87,28 @@
                     <p class="card-subtitle">Capture the essentials, assign talent, and keep clients delighted.</p>
                 </div>
             </div>
-            <form>
+            <form id="eventForm">
                 <div class="form-grid">
                     <div class="form-field">
                         <label for="eventName">Event name</label>
-                        <input id="eventName" type="text" placeholder="E.g. Winter Soirée" />
+                        <input id="eventName" name="eventName" type="text" placeholder="E.g. Winter Soirée" required />
                     </div>
                     <div class="form-field">
                         <label for="eventDate">Date</label>
-                        <input id="eventDate" type="date" />
+                        <input id="eventDate" name="eventDate" type="date" required />
                     </div>
                     <div class="form-field">
                         <label for="eventTime">Start time</label>
-                        <input id="eventTime" type="time" />
+                        <input id="eventTime" name="eventTime" type="time" />
                     </div>
                     <div class="form-field">
                         <label for="eventLocation">Location</label>
-                        <input id="eventLocation" type="text" placeholder="Venue or address" />
+                        <input id="eventLocation" name="eventLocation" type="text" placeholder="Venue or address" />
                     </div>
                     <div class="form-field">
                         <label for="eventPackage">Service package</label>
-                        <select id="eventPackage">
-                            <option selected disabled>Select package</option>
+                        <select id="eventPackage" name="eventPackage" required>
+                            <option value="" disabled selected>Select package</option>
                             <option>Signature Cocktail Bar</option>
                             <option>Premium Mixology</option>
                             <option>Interactive Workshop</option>
@@ -164,12 +117,38 @@
                     </div>
                     <div class="form-field">
                         <label for="guestCount">Guest count</label>
-                        <input id="guestCount" type="number" min="0" placeholder="Expected attendees" />
+                        <input id="guestCount" name="guestCount" type="number" min="0" placeholder="Expected attendees" />
+                    </div>
+                    <div class="form-field">
+                        <label for="eventPayout">Estimated payout (USD)</label>
+                        <input id="eventPayout" name="eventPayout" type="number" min="0" step="50" placeholder="0" />
+                    </div>
+                </div>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <label for="eventStatus">Event status</label>
+                        <select id="eventStatus" name="eventStatus" required>
+                            <option value="Confirmed" data-level="success" selected>Confirmed</option>
+                            <option value="Awaiting deposit" data-level="warning">Awaiting deposit</option>
+                            <option value="Contract overdue" data-level="danger">Contract overdue</option>
+                            <option value="Proposal sent" data-level="info">Proposal sent</option>
+                            <option value="Draft" data-level="neutral">Draft</option>
+                        </select>
+                    </div>
+                    <div class="form-field">
+                        <label for="eventStaffing">Staffing status</label>
+                        <select id="eventStaffing" name="eventStaffing" required>
+                            <option value="Unassigned" data-level="danger" selected>Unassigned</option>
+                            <option value="Needs 1 bartender" data-level="warning">Needs 1 bartender</option>
+                            <option value="Needs 2 bartenders" data-level="warning">Needs 2 bartenders</option>
+                            <option value="Ready" data-level="success">Ready</option>
+                            <option value="Fully staffed" data-level="success">Fully staffed</option>
+                        </select>
                     </div>
                 </div>
                 <div class="form-field">
                     <label for="eventNotes">Notes & client preferences</label>
-                    <textarea id="eventNotes" placeholder="Share tastings, specialty cocktails, or logistics." ></textarea>
+                    <textarea id="eventNotes" name="eventNotes" placeholder="Share tastings, specialty cocktails, or logistics." ></textarea>
                 </div>
                 <div class="table-actions" style="justify-content: flex-end;">
                     <button class="button ghost" type="reset">Clear</button>
@@ -181,23 +160,8 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-
-        const tabs = document.querySelectorAll('.tab');
-        tabs.forEach((tab) => {
-            tab.addEventListener('click', () => {
-                tabs.forEach((button) => button.classList.remove('active'));
-                tab.classList.add('active');
-            });
-        });
-    </script>
+    <script src="scripts/data-store.js"></script>
+    <script src="scripts/common.js"></script>
+    <script src="scripts/events.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,22 +50,22 @@
         <section class="card-grid stats-grid">
             <article class="stat-card">
                 <span class="stat-card__label">Total events</span>
-                <span class="stat-card__value">12</span>
+                <span class="stat-card__value" id="totalEventsStat">0</span>
                 <span class="stat-card__meta success">+2 vs last week</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Team availability</span>
-                <span class="stat-card__value">8 / 10</span>
-                <span class="stat-card__meta warning">2 on PTO</span>
+                <span class="stat-card__value" id="teamAvailabilityStat">0 / 0</span>
+                <span class="stat-card__meta warning">Live availability updates</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Next event</span>
-                <span class="stat-card__value" style="font-size:1.6rem;">Corporate Party</span>
-                <span class="stat-card__meta">Oct 5 · 7:00 PM</span>
+                <span class="stat-card__value" id="nextEventName" style="font-size:1.6rem;">No events scheduled</span>
+                <span class="stat-card__meta" id="nextEventMeta">Add an event to build your schedule.</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Action needed</span>
-                <span class="stat-card__value" style="color: var(--danger-500);">3</span>
+                <span class="stat-card__value" id="actionNeededStat" style="color: var(--danger-500);">0</span>
                 <span class="stat-card__meta danger">Unassigned shifts</span>
             </article>
         </section>
@@ -79,48 +79,7 @@
                     </div>
                     <a class="card-action" href="events.html">View all activity →</a>
                 </div>
-                <div class="timeline">
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">✅</span>
-                            <div>
-                                <h3 class="person-card__name">Wedding Reception booked</h3>
-                                <p class="card-subtitle">Oct 15 · The Grand Hall · Deposit received</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">2 minutes ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">👤</span>
-                            <div>
-                                <h3 class="person-card__name">John Doe assigned</h3>
-                                <p class="card-subtitle">Corporate Party · Bar Lead confirmed</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">1 hour ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">📝</span>
-                            <div>
-                                <h3 class="person-card__name">Availability updated</h3>
-                                <p class="card-subtitle">Jane Smith marked unavailable on Nov 1</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">4 hours ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">📦</span>
-                            <div>
-                                <h3 class="person-card__name">Inventory check</h3>
-                                <p class="card-subtitle">Glassware restocked · Ready for tasting events</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">Yesterday</span>
-                    </div>
-                </div>
+                <div class="timeline" id="activityFeed"></div>
             </article>
 
             <article class="content-card">
@@ -138,7 +97,7 @@
                         </button>
                         <div class="accordion-content" id="alert-1" data-open="true">
                             <div class="accordion-content__inner">
-                                <p>Assign barbacks for the Corporate Party cocktail hour. Current schedule has no coverage from 6–7 PM.</p>
+                                <ul id="staffingAlertsList" class="alert-list"></ul>
                                 <a class="card-action" href="employees.html">Review available team →</a>
                             </div>
                         </div>
@@ -230,21 +189,16 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
+    <script src="scripts/data-store.js"></script>
+    <script src="scripts/common.js"></script>
     <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-
-        const accordionTriggers = document.querySelectorAll('.accordion-trigger');
-        accordionTriggers.forEach((trigger) => {
+        document.querySelectorAll('.accordion-trigger').forEach((trigger) => {
             const targetId = trigger.getAttribute('data-accordion-target');
             const content = document.getElementById(targetId);
-            if (!content) return;
+
+            if (!content) {
+                return;
+            }
 
             if (content.dataset.open === 'true') {
                 content.style.maxHeight = content.scrollHeight + 'px';
@@ -256,11 +210,14 @@
 
                 if (!isExpanded) {
                     content.style.maxHeight = content.scrollHeight + 'px';
+                    content.dataset.open = 'true';
                 } else {
                     content.style.maxHeight = '0px';
+                    content.dataset.open = 'false';
                 }
             });
         });
     </script>
+    <script src="scripts/dashboard.js"></script>
 </body>
 </html>

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -1,0 +1,159 @@
+(function () {
+    const MONTH_NAMES = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+    ];
+
+    function formatNumber(value) {
+        const numberValue = Number(value);
+        if (Number.isNaN(numberValue)) {
+            return value || '—';
+        }
+        return new Intl.NumberFormat('en-US').format(numberValue);
+    }
+
+    function deriveTeamSize(event) {
+        if (event.teamSize) {
+            return event.teamSize;
+        }
+
+        if (!event.guestCount) {
+            return 2;
+        }
+
+        return Math.max(2, Math.ceil(Number(event.guestCount) / 40));
+    }
+
+    function derivePrepHours(event) {
+        if (event.prepHours) {
+            return event.prepHours;
+        }
+
+        if (!event.guestCount) {
+            return 3;
+        }
+
+        return Math.max(3, Math.ceil(Number(event.guestCount) / 50) * 2);
+    }
+
+    function renderCalendar() {
+        const grid = document.getElementById('calendarGrid');
+        const title = document.getElementById('calendarMonthTitle');
+
+        if (!grid || !title) {
+            return;
+        }
+
+        const eventsWithDates = window.B2UStore
+            .getEvents()
+            .map((event) => ({
+                ...event,
+                dateObject: new Date(event.date || ''),
+            }))
+            .filter((event) => !Number.isNaN(event.dateObject.getTime()))
+            .sort((a, b) => a.dateObject.getTime() - b.dateObject.getTime());
+
+        const referenceDate = eventsWithDates.length ? eventsWithDates[0].dateObject : new Date();
+        const monthStart = new Date(referenceDate.getFullYear(), referenceDate.getMonth(), 1);
+        const month = monthStart.getMonth();
+        const year = monthStart.getFullYear();
+        const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+        title.textContent = `${MONTH_NAMES[month]} ${year} overview`;
+
+        const events = eventsWithDates.filter(
+            (event) => event.dateObject.getMonth() === month && event.dateObject.getFullYear() === year
+        );
+
+        grid.innerHTML = '';
+
+        for (let day = 1; day <= daysInMonth; day += 1) {
+            const cell = document.createElement('div');
+            cell.className = 'calendar-cell';
+
+            const dateLabel = document.createElement('span');
+            dateLabel.className = 'calendar-cell__date';
+            const date = new Date(year, month, day);
+            dateLabel.textContent = `${date.toLocaleDateString('en-US', { weekday: 'short' })} ${day}`;
+            cell.appendChild(dateLabel);
+
+            const eventsForDay = events.filter((event) => event.dateObject.getDate() === day);
+
+            eventsForDay.forEach((event) => {
+                const eventTitle = document.createElement('div');
+                eventTitle.className = 'calendar-event';
+                eventTitle.textContent = event.name;
+                cell.appendChild(eventTitle);
+
+                const subtitle = document.createElement('p');
+                subtitle.className = 'card-subtitle';
+                subtitle.textContent = `${formatNumber(event.guestCount)} guests · ${deriveTeamSize(event)} staff`;
+                cell.appendChild(subtitle);
+            });
+
+            grid.appendChild(cell);
+        }
+    }
+
+    function renderWeekAtGlance() {
+        const tableBody = document.getElementById('weekAtGlanceBody');
+
+        if (!tableBody) {
+            return;
+        }
+
+        const events = window.B2UStore
+            .getEvents()
+            .map((event) => ({
+                ...event,
+                dateObject: new Date(`${event.date || ''}T${event.time || '00:00'}`),
+            }))
+            .filter((event) => !Number.isNaN(event.dateObject.getTime()))
+            .sort((a, b) => a.dateObject.getTime() - b.dateObject.getTime())
+            .slice(0, 5);
+
+        tableBody.innerHTML = '';
+
+        if (!events.length) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 4;
+            cell.className = 'empty-state';
+            cell.textContent = 'No upcoming events scheduled. Add events to populate the calendar.';
+            row.appendChild(cell);
+            tableBody.appendChild(row);
+            return;
+        }
+
+        events.forEach((event) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td data-label="Event">${event.name}</td>
+                <td data-label="Guests">${formatNumber(event.guestCount)}</td>
+                <td data-label="Team">${deriveTeamSize(event)}</td>
+                <td data-label="Prep hours">${derivePrepHours(event)}</td>
+            `;
+            tableBody.appendChild(row);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.B2UStore) {
+            console.warn('B2UStore is not available. Calendar cannot be rendered.');
+            return;
+        }
+
+        renderCalendar();
+        renderWeekAtGlance();
+    });
+})();

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,0 +1,12 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', () => {
+        const navToggle = document.getElementById('mobileNavToggle');
+        const nav = document.getElementById('primaryNav');
+
+        if (navToggle && nav) {
+            navToggle.addEventListener('click', () => {
+                nav.classList.toggle('open');
+            });
+        }
+    });
+})();

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -1,0 +1,192 @@
+(function () {
+    function formatDate(dateString, timeString) {
+        if (!dateString) {
+            return { date: 'TBD', meta: '' };
+        }
+
+        const date = new Date(`${dateString}T${timeString || '00:00'}`);
+
+        if (Number.isNaN(date.getTime())) {
+            return { date: dateString, meta: timeString || '' };
+        }
+
+        const dateText = new Intl.DateTimeFormat('en-US', {
+            month: 'short',
+            day: 'numeric',
+        }).format(date);
+
+        const timeText = timeString
+            ? new Intl.DateTimeFormat('en-US', {
+                  hour: 'numeric',
+                  minute: '2-digit',
+              }).format(date)
+            : '';
+
+        return { date: dateText, meta: timeText };
+    }
+
+    function formatRelativeTime(timestamp) {
+        if (!timestamp) {
+            return 'Just now';
+        }
+
+        const deltaSeconds = Math.round((Date.now() - timestamp) / 1000);
+
+        const intervals = [
+            { label: 'day', seconds: 60 * 60 * 24 },
+            { label: 'hour', seconds: 60 * 60 },
+            { label: 'minute', seconds: 60 },
+        ];
+
+        for (const interval of intervals) {
+            const count = Math.floor(deltaSeconds / interval.seconds);
+            if (count >= 1) {
+                return `${count} ${interval.label}${count > 1 ? 's' : ''} ago`;
+            }
+        }
+
+        return 'Just now';
+    }
+
+    function updateStats() {
+        const events = window.B2UStore.getEvents();
+        const employees = window.B2UStore.getEmployees();
+
+        const totalEventsElement = document.getElementById('totalEventsStat');
+        const teamAvailabilityElement = document.getElementById('teamAvailabilityStat');
+        const nextEventNameElement = document.getElementById('nextEventName');
+        const nextEventMetaElement = document.getElementById('nextEventMeta');
+        const actionNeededElement = document.getElementById('actionNeededStat');
+
+        if (totalEventsElement) {
+            totalEventsElement.textContent = String(events.length);
+        }
+
+        if (teamAvailabilityElement) {
+            const availableCount = employees.filter((employee) => employee.statusLevel === 'success').length;
+            teamAvailabilityElement.textContent = `${availableCount} / ${employees.length || 0}`;
+
+            const availabilityMeta = teamAvailabilityElement.nextElementSibling;
+            if (availabilityMeta && availabilityMeta.classList.contains('stat-card__meta')) {
+                availabilityMeta.textContent = `${availableCount} team members ready`;
+            }
+        }
+
+        if (nextEventNameElement && nextEventMetaElement) {
+            const upcoming = events
+                .map((event) => ({
+                    ...event,
+                    dateObject: new Date(`${event.date || ''}T${event.time || '00:00'}`),
+                }))
+                .filter((event) => !Number.isNaN(event.dateObject.getTime()))
+                .sort((a, b) => a.dateObject.getTime() - b.dateObject.getTime());
+
+            if (upcoming.length) {
+                const next = upcoming[0];
+                const formatted = formatDate(next.date, next.time);
+                nextEventNameElement.textContent = next.name;
+                nextEventMetaElement.textContent = `${formatted.date} · ${formatted.meta || 'Time TBD'}`;
+            } else {
+                nextEventNameElement.textContent = 'No events scheduled';
+                nextEventMetaElement.textContent = 'Add an event to build your schedule.';
+            }
+        }
+
+        if (actionNeededElement) {
+            const riskyEvents = events.filter((event) => event.staffingLevel === 'warning' || event.staffingLevel === 'danger');
+            actionNeededElement.textContent = String(riskyEvents.length);
+        }
+    }
+
+    function renderActivityFeed() {
+        const container = document.getElementById('activityFeed');
+
+        if (!container) {
+            return;
+        }
+
+        const events = window.B2UStore.getEvents().map((event) => ({
+            type: 'event',
+            title: `${event.name} scheduled`,
+            subtitle: `${event.location || 'Location TBA'} · ${event.package || 'Package TBD'}`,
+            createdAt: event.createdAt,
+        }));
+
+        const employees = window.B2UStore.getEmployees().map((employee) => ({
+            type: 'employee',
+            title: `${employee.name} joined the roster`,
+            subtitle: `${employee.role || 'Role TBD'} · ${employee.status || 'Status pending'}`,
+            createdAt: employee.createdAt,
+        }));
+
+        const combined = [...events, ...employees]
+            .filter((item) => item.createdAt)
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .slice(0, 6);
+
+        container.innerHTML = '';
+
+        if (!combined.length) {
+            container.innerHTML = '<p class="empty-state">No activity yet. Add events or employees to see updates here.</p>';
+            return;
+        }
+
+        combined.forEach((item) => {
+            const timelineItem = document.createElement('div');
+            timelineItem.className = 'timeline-item';
+            const icon = item.type === 'event' ? '📅' : '👤';
+
+            timelineItem.innerHTML = `
+                <div class="timeline-item__left">
+                    <span class="timeline-icon">${icon}</span>
+                    <div>
+                        <h3 class="person-card__name">${item.title}</h3>
+                        <p class="card-subtitle">${item.subtitle}</p>
+                    </div>
+                </div>
+                <span class="timeline-item__meta">${formatRelativeTime(item.createdAt)}</span>
+            `;
+
+            container.appendChild(timelineItem);
+        });
+    }
+
+    function renderStaffingAlerts() {
+        const list = document.getElementById('staffingAlertsList');
+
+        if (!list) {
+            return;
+        }
+
+        const events = window.B2UStore.getEvents().filter(
+            (event) => event.staffingLevel === 'warning' || event.staffingLevel === 'danger'
+        );
+
+        list.innerHTML = '';
+
+        if (!events.length) {
+            list.innerHTML = '<li>All events are fully staffed. Great job!</li>';
+            return;
+        }
+
+        events.forEach((event) => {
+            const item = document.createElement('li');
+            const formatted = formatDate(event.date, event.time);
+            item.innerHTML = `<strong>${event.name}</strong> · ${event.staffingStatus || 'Needs attention'}<br /><span class="card-subtitle">${
+                formatted.date
+            } · ${formatted.meta || 'Time TBD'} · ${event.location || 'Location TBA'}</span>`;
+            list.appendChild(item);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.B2UStore) {
+            console.warn('B2UStore is not available. Dashboard data cannot be rendered.');
+            return;
+        }
+
+        updateStats();
+        renderActivityFeed();
+        renderStaffingAlerts();
+    });
+})();

--- a/scripts/data-store.js
+++ b/scripts/data-store.js
@@ -1,0 +1,270 @@
+(function () {
+    const STORAGE_KEY = 'bartending2uScheduler';
+
+    const defaultData = {
+        events: [
+            {
+                id: 'evt-1',
+                name: 'Corporate Party',
+                date: '2025-10-05',
+                time: '19:00',
+                location: 'Downtown Houston',
+                package: 'Signature Cocktail Bar',
+                guestCount: 120,
+                payout: 3800,
+                status: 'Confirmed',
+                statusLevel: 'success',
+                staffingStatus: 'Fully staffed',
+                staffingLevel: 'success',
+                notes: 'Deposit received. Call time 6:00 PM.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 24 * 3,
+            },
+            {
+                id: 'evt-2',
+                name: 'Wedding Reception',
+                date: '2025-10-15',
+                time: '18:30',
+                location: 'The Grand Hall',
+                package: 'Premium Mixology',
+                guestCount: 180,
+                payout: 5200,
+                status: 'Awaiting deposit',
+                statusLevel: 'warning',
+                staffingStatus: 'Needs 2 bartenders',
+                staffingLevel: 'warning',
+                notes: 'Send reminder for deposit. Discuss signature cocktail list.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 24 * 4,
+            },
+            {
+                id: 'evt-3',
+                name: 'Holiday Gala',
+                date: '2025-11-30',
+                time: '20:00',
+                location: 'Skyline Ballroom',
+                package: 'Craft Experience',
+                guestCount: 250,
+                payout: 7600,
+                status: 'Contract overdue',
+                statusLevel: 'danger',
+                staffingStatus: 'Partial coverage',
+                staffingLevel: 'warning',
+                notes: 'Client reviewing updated package. Follow up Friday.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 24 * 2,
+            },
+            {
+                id: 'evt-4',
+                name: 'Mixology Workshop',
+                date: '2025-12-03',
+                time: '17:30',
+                location: 'Private Residence',
+                package: 'Interactive Workshop',
+                guestCount: 25,
+                payout: 1400,
+                status: 'Confirmed',
+                statusLevel: 'success',
+                staffingStatus: 'Ready',
+                staffingLevel: 'success',
+                notes: 'Include mocktail options and allergy-friendly mixers.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 24 * 1,
+            },
+        ],
+        employees: [
+            {
+                id: 'emp-1',
+                name: 'John Doe',
+                role: 'Bar Lead · Flair certified',
+                email: 'john.doe@bartending2u.com',
+                phone: '(555) 100-2000',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Expert in corporate activations.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 8,
+            },
+            {
+                id: 'emp-2',
+                name: 'Jane Smith',
+                role: 'Mixologist · Mocktail specialist',
+                email: 'jane.smith@bartending2u.com',
+                phone: '(555) 222-3333',
+                status: 'On PTO',
+                statusLevel: 'warning',
+                notes: 'Out Oct 10 - Oct 16.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 12,
+            },
+            {
+                id: 'emp-3',
+                name: 'Alex Rivera',
+                role: 'Bartender · Bilingual',
+                email: 'alex.rivera@bartending2u.com',
+                phone: '(555) 444-5555',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Spanish/English. Comfortable with large crowds.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 6,
+            },
+            {
+                id: 'emp-4',
+                name: 'Priya Singh',
+                role: 'Mixology Lead · Seasonal menu',
+                email: 'priya.singh@bartending2u.com',
+                phone: '(555) 777-8888',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Specializes in custom experiences.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 10,
+            },
+            {
+                id: 'emp-5',
+                name: 'Jamie Lee',
+                role: 'Support · Prep specialist',
+                email: 'jamie.lee@bartending2u.com',
+                phone: '(555) 999-1212',
+                status: 'Limited hours',
+                statusLevel: 'warning',
+                notes: 'Available evenings only.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 5,
+            },
+            {
+                id: 'emp-6',
+                name: 'Marcus Allen',
+                role: 'Barback',
+                email: 'marcus.allen@bartending2u.com',
+                phone: '(555) 313-1414',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Strong with load-in/load-out logistics.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 7,
+            },
+        ],
+    };
+
+    let cache;
+
+    function clone(data) {
+        return JSON.parse(JSON.stringify(data));
+    }
+
+    function normalizeData(data) {
+        if (!data || typeof data !== 'object') {
+            return clone(defaultData);
+        }
+
+        const normalized = {
+            events: Array.isArray(data.events) ? data.events : [],
+            employees: Array.isArray(data.employees) ? data.employees : [],
+        };
+
+        return normalized;
+    }
+
+    function loadFromStorage() {
+        if (cache) {
+            return cache;
+        }
+
+        const storedValue = localStorage.getItem(STORAGE_KEY);
+
+        if (!storedValue) {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultData));
+            cache = clone(defaultData);
+            return cache;
+        }
+
+        try {
+            const parsed = JSON.parse(storedValue);
+            cache = normalizeData(parsed);
+        } catch (error) {
+            console.warn('Unable to parse stored scheduler data. Reverting to defaults.', error);
+            cache = clone(defaultData);
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+        }
+
+        return cache;
+    }
+
+    function persist(data) {
+        cache = normalizeData(data);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+        return cache;
+    }
+
+    function generateId(prefix) {
+        if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+            return `${prefix}-${crypto.randomUUID()}`;
+        }
+
+        return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    function addEvent(event) {
+        const current = loadFromStorage();
+        const newEvent = {
+            id: generateId('evt'),
+            createdAt: Date.now(),
+            ...event,
+        };
+
+        current.events.push(newEvent);
+        persist(current);
+        return newEvent;
+    }
+
+    function removeEvent(eventId) {
+        const current = loadFromStorage();
+        current.events = current.events.filter((event) => event.id !== eventId);
+        persist(current);
+    }
+
+    function addEmployee(employee) {
+        const current = loadFromStorage();
+        const newEmployee = {
+            id: generateId('emp'),
+            createdAt: Date.now(),
+            ...employee,
+        };
+
+        current.employees.push(newEmployee);
+        persist(current);
+        return newEmployee;
+    }
+
+    function removeEmployee(employeeId) {
+        const current = loadFromStorage();
+        current.employees = current.employees.filter((employee) => employee.id !== employeeId);
+        persist(current);
+    }
+
+    function getEvents() {
+        const current = loadFromStorage();
+        return clone(current.events);
+    }
+
+    function getEmployees() {
+        const current = loadFromStorage();
+        return clone(current.employees);
+    }
+
+    function saveData(data) {
+        return clone(persist(data));
+    }
+
+    function clearAll() {
+        cache = clone(defaultData);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+    }
+
+    window.B2UStore = {
+        getData() {
+            return clone(loadFromStorage());
+        },
+        saveData,
+        getEvents,
+        addEvent,
+        removeEvent,
+        getEmployees,
+        addEmployee,
+        removeEmployee,
+        clearAll,
+        defaultData: clone(defaultData),
+    };
+})();

--- a/scripts/employees.js
+++ b/scripts/employees.js
@@ -1,0 +1,144 @@
+(function () {
+    function getBadgeClass(level) {
+        if (!level) {
+            return 'badge';
+        }
+
+        return `badge ${level}`;
+    }
+
+    function renderEmployees() {
+        const list = document.getElementById('employeeList');
+
+        if (!list) {
+            return;
+        }
+
+        const employees = window.B2UStore.getEmployees().sort((a, b) => a.name.localeCompare(b.name));
+        list.innerHTML = '';
+
+        if (!employees.length) {
+            const empty = document.createElement('p');
+            empty.className = 'empty-state';
+            empty.textContent = 'No team members yet. Invite your first bartender to get started.';
+            list.appendChild(empty);
+            return;
+        }
+
+        employees.forEach((employee) => {
+            const card = document.createElement('article');
+            card.className = 'person-card';
+            card.innerHTML = `
+                <div class="person-card__top">
+                    <div>
+                        <h3 class="person-card__name">${employee.name || 'Unnamed teammate'}</h3>
+                        <p class="person-card__role">${employee.role || ''}</p>
+                    </div>
+                    <button type="button" class="card-action person-card__remove" data-id="${employee.id}">Remove</button>
+                </div>
+                <div class="person-card__status"><span class="${getBadgeClass(employee.statusLevel)}">${employee.status || 'Available'}</span></div>
+                <ul class="person-card__meta">
+                    ${employee.email ? `<li>Email: <a href="mailto:${employee.email}">${employee.email}</a></li>` : ''}
+                    ${employee.phone ? `<li>Phone: <a href="tel:${employee.phone}">${employee.phone}</a></li>` : ''}
+                    ${employee.notes ? `<li>${employee.notes}</li>` : ''}
+                </ul>
+            `;
+
+            list.appendChild(card);
+        });
+
+        list.querySelectorAll('.person-card__remove').forEach((button) => {
+            button.addEventListener('click', (event) => {
+                const { id } = event.currentTarget.dataset;
+
+                if (confirm('Remove this team member from your roster?')) {
+                    window.B2UStore.removeEmployee(id);
+                    renderEmployees();
+                    updateStats();
+                }
+            });
+        });
+    }
+
+    function updateStats() {
+        const totalElement = document.getElementById('activeStaffCount');
+        const rolesElement = document.getElementById('rolesCovered');
+        const ptoElement = document.getElementById('upcomingPto');
+
+        const employees = window.B2UStore.getEmployees();
+        const activeCount = employees.length;
+        const availableCount = employees.filter((employee) => {
+            const normalizedLevel = (employee.statusLevel || '').toLowerCase();
+            if (normalizedLevel === 'success') {
+                return true;
+            }
+
+            const normalizedStatus = (employee.status || '').toLowerCase();
+            return normalizedStatus === 'available';
+        }).length;
+        const warningCount = employees.filter((employee) => employee.statusLevel === 'warning').length;
+        const uniqueRoles = new Set(
+            employees
+                .map((employee) => employee.role || '')
+                .filter((role) => role)
+                .map((role) => role.split('·')[0].trim())
+        );
+
+        if (totalElement) {
+            totalElement.textContent = String(activeCount);
+            const meta = totalElement.nextElementSibling;
+
+            if (meta && meta.classList.contains('stat-card__meta')) {
+                meta.textContent = `${availableCount} available this week`;
+            }
+        }
+
+        if (rolesElement) {
+            rolesElement.textContent = String(uniqueRoles.size || '—');
+        }
+
+        if (ptoElement) {
+            ptoElement.textContent = String(warningCount);
+        }
+    }
+
+    function handleFormSubmission() {
+        const form = document.getElementById('employeeForm');
+
+        if (!form) {
+            return;
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            const statusSelect = form.querySelector('#teamStatus');
+
+            const newEmployee = {
+                name: form.teamName.value.trim(),
+                role: form.teamRole.value,
+                email: form.teamEmail.value.trim(),
+                phone: form.teamPhone.value.trim(),
+                notes: form.teamNotes.value.trim(),
+                status: statusSelect ? statusSelect.value : 'Available',
+                statusLevel: statusSelect ? statusSelect.options[statusSelect.selectedIndex].dataset.level : 'success',
+            };
+
+            window.B2UStore.addEmployee(newEmployee);
+            form.reset();
+            renderEmployees();
+            updateStats();
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.B2UStore) {
+            console.warn('B2UStore is not available. Unable to manage employees.');
+            return;
+        }
+
+        renderEmployees();
+        updateStats();
+        handleFormSubmission();
+    });
+})();

--- a/scripts/events.js
+++ b/scripts/events.js
@@ -1,0 +1,254 @@
+(function () {
+    function formatDate(dateString) {
+        if (!dateString) {
+            return 'TBD';
+        }
+
+        const date = new Date(dateString);
+
+        if (Number.isNaN(date.getTime())) {
+            return dateString;
+        }
+
+        return new Intl.DateTimeFormat('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+        }).format(date);
+    }
+
+    function formatTime(timeString) {
+        if (!timeString) {
+            return 'TBD';
+        }
+
+        const [hours, minutes] = timeString.split(':').map(Number);
+
+        if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+            return timeString;
+        }
+
+        const date = new Date();
+        date.setHours(hours, minutes, 0, 0);
+
+        return new Intl.DateTimeFormat('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+        }).format(date);
+    }
+
+    function formatCurrency(value) {
+        if (value === undefined || value === null || value === '') {
+            return '—';
+        }
+
+        const numberValue = Number(value);
+
+        if (Number.isNaN(numberValue)) {
+            return value;
+        }
+
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: 'USD',
+            maximumFractionDigits: 0,
+        }).format(numberValue);
+    }
+
+    function formatGuests(value) {
+        if (value === undefined || value === null || value === '') {
+            return '—';
+        }
+
+        const numberValue = Number(value);
+
+        if (Number.isNaN(numberValue)) {
+            return value;
+        }
+
+        return new Intl.NumberFormat('en-US').format(numberValue);
+    }
+
+    function getBadgeClass(level) {
+        if (!level) {
+            return 'badge';
+        }
+
+        return `badge ${level}`;
+    }
+
+    function buildDetailsRow(event, columnCount) {
+        const detailsRow = document.createElement('tr');
+        detailsRow.className = 'event-details';
+        detailsRow.hidden = true;
+
+        const detailsCell = document.createElement('td');
+        detailsCell.colSpan = columnCount;
+
+        const details = [];
+
+        if (event.notes) {
+            details.push(`<strong>Notes:</strong> ${event.notes}`);
+        }
+
+        const meta = [];
+
+        if (event.payout !== undefined && event.payout !== null && event.payout !== '') {
+            meta.push(`Payout ${formatCurrency(event.payout)}`);
+        }
+
+        if (event.guestCount !== undefined && event.guestCount !== null && event.guestCount !== '') {
+            meta.push(`${formatGuests(event.guestCount)} guests`);
+        }
+
+        if (meta.length) {
+            details.unshift(`<strong>Overview:</strong> ${meta.join(' · ')}`);
+        }
+
+        if (!details.length) {
+            details.push('No additional details recorded yet.');
+        }
+
+        detailsCell.innerHTML = `<div class="event-details__inner">${details
+            .map((item) => `<p>${item}</p>`)
+            .join('')}</div>`;
+        detailsRow.appendChild(detailsCell);
+
+        return detailsRow;
+    }
+
+    function attachRowActions(row, detailsRow, eventId) {
+        const viewButton = row.querySelector('.js-view-event');
+        const deleteButton = row.querySelector('.js-delete-event');
+
+        if (viewButton) {
+            viewButton.addEventListener('click', () => {
+                const isHidden = detailsRow.hidden;
+                detailsRow.hidden = !isHidden;
+                viewButton.textContent = isHidden ? 'Hide details' : 'View details';
+            });
+        }
+
+        if (deleteButton) {
+            deleteButton.addEventListener('click', () => {
+                if (confirm('Remove this event from your schedule?')) {
+                    window.B2UStore.removeEvent(eventId);
+                    renderEvents();
+                }
+            });
+        }
+    }
+
+    function renderEvents() {
+        const tableBody = document.getElementById('eventsTableBody');
+
+        if (!tableBody) {
+            return;
+        }
+
+        const events = window.B2UStore.getEvents().sort((a, b) => {
+            const first = new Date(`${a.date || ''}T${a.time || '00:00'}`);
+            const second = new Date(`${b.date || ''}T${b.time || '00:00'}`);
+
+            const firstTime = first.getTime();
+            const secondTime = second.getTime();
+
+            const safeFirst = Number.isNaN(firstTime) ? Number.MAX_SAFE_INTEGER : firstTime;
+            const safeSecond = Number.isNaN(secondTime) ? Number.MAX_SAFE_INTEGER : secondTime;
+
+            return safeFirst - safeSecond;
+        });
+
+        tableBody.innerHTML = '';
+
+        if (!events.length) {
+            const emptyRow = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 9;
+            cell.className = 'empty-state';
+            cell.textContent = 'No events logged yet. Add your first event to start tracking details.';
+            emptyRow.appendChild(cell);
+            tableBody.appendChild(emptyRow);
+            return;
+        }
+
+        events.forEach((event) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td data-label="Event">${event.name || 'Untitled event'}</td>
+                <td data-label="Date">${formatDate(event.date)}<div class="table-meta">${formatTime(event.time)}</div></td>
+                <td data-label="Location">${event.location || '—'}</td>
+                <td data-label="Package">${event.package || '—'}</td>
+                <td data-label="Guests">${formatGuests(event.guestCount)}</td>
+                <td data-label="Payout">${formatCurrency(event.payout)}</td>
+                <td data-label="Status"><span class="${getBadgeClass(event.statusLevel)}">${event.status || 'Pending'}</span></td>
+                <td data-label="Staffing"><span class="${getBadgeClass(event.staffingLevel)}">${event.staffingStatus || 'Unassigned'}</span></td>
+                <td class="table-actions" data-label="Actions">
+                    <button type="button" class="card-action js-view-event">View details</button>
+                    <button type="button" class="card-action js-delete-event">Remove</button>
+                </td>
+            `;
+
+            const detailsRow = buildDetailsRow(event, 9);
+
+            tableBody.appendChild(row);
+            tableBody.appendChild(detailsRow);
+
+            attachRowActions(row, detailsRow, event.id);
+        });
+    }
+
+    function handleFormSubmission() {
+        const form = document.getElementById('eventForm');
+
+        if (!form) {
+            return;
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            const statusSelect = form.querySelector('#eventStatus');
+            const staffingSelect = form.querySelector('#eventStaffing');
+
+            const newEvent = {
+                name: form.eventName.value.trim(),
+                date: form.eventDate.value,
+                time: form.eventTime.value,
+                location: form.eventLocation.value.trim(),
+                package: form.eventPackage.value,
+                guestCount: form.guestCount.value ? Number(form.guestCount.value) : '',
+                payout: form.eventPayout.value ? Number(form.eventPayout.value) : '',
+                status: statusSelect ? statusSelect.value : 'Pending',
+                statusLevel: statusSelect ? statusSelect.options[statusSelect.selectedIndex].dataset.level : 'info',
+                staffingStatus: staffingSelect ? staffingSelect.value : 'Unassigned',
+                staffingLevel: staffingSelect
+                    ? staffingSelect.options[staffingSelect.selectedIndex].dataset.level
+                    : 'warning',
+                notes: form.eventNotes.value.trim(),
+            };
+
+            window.B2UStore.addEvent(newEvent);
+            form.reset();
+            renderEvents();
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.B2UStore) {
+            console.warn('B2UStore is not available. Unable to render events.');
+            return;
+        }
+
+        renderEvents();
+        handleFormSubmission();
+
+        const tabs = document.querySelectorAll('.tab');
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                tabs.forEach((button) => button.classList.remove('active'));
+                tab.classList.add('active');
+            });
+        });
+    });
+})();

--- a/settings.html
+++ b/settings.html
@@ -142,15 +142,6 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
-    <script>
-        const navToggle = document.getElementById('mobileNavToggle');
-        const nav = document.getElementById('primaryNav');
-
-        if (navToggle && nav) {
-            navToggle.addEventListener('click', () => {
-                nav.classList.toggle('open');
-            });
-        }
-    </script>
+    <script src="scripts/common.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -305,6 +305,15 @@ img {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.card-action:hover {
+  color: var(--primary-700);
+  text-decoration: underline;
 }
 
 .timeline {
@@ -368,6 +377,16 @@ img {
   color: var(--warning-500);
 }
 
+.badge.info {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-600);
+}
+
+.badge.neutral {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--slate-600);
+}
+
 .split-layout {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -423,6 +442,25 @@ img {
   gap: 0.6rem;
 }
 
+.alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.alert-list li {
+  font-size: 0.9rem;
+  color: var(--slate-600);
+  line-height: 1.4;
+}
+
+.alert-list strong {
+  color: var(--slate-900);
+}
+
 .table-wrapper {
   overflow-x: auto;
 }
@@ -463,6 +501,33 @@ tr:hover td {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+}
+
+.table-meta {
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--slate-500);
+}
+
+.event-details {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.event-details__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.1rem 0.5rem;
+  color: var(--slate-600);
+  font-size: 0.9rem;
+}
+
+.event-details td {
+  border-bottom: none;
+}
+
+.event-details:hover td {
+  background: none;
 }
 
 .button {
@@ -611,6 +676,13 @@ textarea {
   gap: 0.4rem;
 }
 
+.person-card__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
 .person-card__name {
   font-size: 1.05rem;
   font-weight: 600;
@@ -623,6 +695,30 @@ textarea {
 
 .person-card__status {
   margin-top: 0.4rem;
+}
+
+.person-card__meta {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--slate-600);
+}
+
+.person-card__meta a {
+  color: var(--primary-600);
+}
+
+.person-card__remove {
+  margin-left: auto;
+  color: var(--danger-500);
+}
+
+.person-card__remove:hover {
+  color: #b91c1c;
 }
 
 .calendar-grid {


### PR DESCRIPTION
## Summary
- add a reusable localStorage data store and shared scripts for navigation and dashboard metrics
- render events, employees, and calendar views from persisted data with forms to add or remove records
- refresh styling for dynamic details, alerts, and staff cards to support the new data-driven UI

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de157cbcd08333b4be40375ce8844a