### PR TITLE
Update employee role options

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -55,8 +55,8 @@
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Roles covered</span>
-                <span class="stat-card__value" style="font-size:1.8rem;">5</span>
-                <span class="stat-card__meta">Bartenders, Mixologists, Leads…</span>
+                <span class="stat-card__value" style="font-size:1.8rem;">4</span>
+                <span class="stat-card__meta">Bartender, Barback, Server, Support</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Upcoming PTO</span>
@@ -75,12 +75,12 @@
             <div class="list-grid">
                 <article class="person-card">
                     <h3 class="person-card__name">John Doe</h3>
-                    <p class="person-card__role">Bar Lead · Flair certified</p>
+                    <p class="person-card__role">Bartender · Lead flair specialist</p>
                     <div class="person-card__status"><span class="badge success">Available</span></div>
                 </article>
                 <article class="person-card">
                     <h3 class="person-card__name">Jane Smith</h3>
-                    <p class="person-card__role">Mixologist · Mocktail specialist</p>
+                    <p class="person-card__role">Server · Guest experience lead</p>
                     <div class="person-card__status"><span class="badge warning">On PTO</span></div>
                 </article>
                 <article class="person-card">
@@ -90,17 +90,17 @@
                 </article>
                 <article class="person-card">
                     <h3 class="person-card__name">Priya Singh</h3>
-                    <p class="person-card__role">Mixology Lead · Seasonal menu</p>
+                    <p class="person-card__role">Barback · Seasonal cocktail prep</p>
                     <div class="person-card__status"><span class="badge success">Available</span></div>
                 </article>
                 <article class="person-card">
                     <h3 class="person-card__name">Jamie Lee</h3>
-                    <p class="person-card__role">Support · Prep specialist</p>
+                    <p class="person-card__role">General support staff · Prep specialist</p>
                     <div class="person-card__status"><span class="badge warning">Limited hours</span></div>
                 </article>
                 <article class="person-card">
                     <h3 class="person-card__name">Marcus Allen</h3>
-                    <p class="person-card__role">Barback</p>
+                    <p class="person-card__role">Barback · Logistics</p>
                     <div class="person-card__status"><span class="badge success">Available</span></div>
                 </article>
             </div>
@@ -167,9 +167,9 @@
                             <select id="teamRole">
                                 <option selected disabled>Select role</option>
                                 <option>Bartender</option>
-                                <option>Mixologist</option>
-                                <option>Bar Lead</option>
-                                <option>Support / Barback</option>
+                                <option>Barback</option>
+                                <option>Server</option>
+                                <option>General Support Staff</option>
                             </select>
                         </div>
                         <div class="form-field">


### PR DESCRIPTION
## Summary
- update the team directory to show the bartender, barback, server, and general support roles
- refresh the add team member form role options to match the new role set
- align the roles covered stat with the revised role list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de1668b4b4833382c4f4c46eaf307b