### PR TITLE
Show John Garcia as the active account in navigation

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -31,6 +31,10 @@
             </nav>
 
             <a class="cta-button" href="events.html">+ New Event</a>
+            <div class="user-profile" aria-label="Account menu">
+                <span class="user-profile__avatar" aria-hidden="true">JG</span>
+                <span class="user-profile__name">John Garcia</span>
+            </div>
         </div>
     </header>
 

--- a/employees.html
+++ b/employees.html
@@ -31,6 +31,10 @@
             </nav>
 
             <a class="cta-button" href="#add-employee">+ Add Team Member</a>
+            <div class="user-profile" aria-label="Account menu">
+                <span class="user-profile__avatar" aria-hidden="true">JG</span>
+                <span class="user-profile__name">John Garcia</span>
+            </div>
         </div>
     </header>
 

--- a/events.html
+++ b/events.html
@@ -31,6 +31,10 @@
             </nav>
 
             <a class="cta-button" href="#new-event">+ New Event</a>
+            <div class="user-profile" aria-label="Account menu">
+                <span class="user-profile__avatar" aria-hidden="true">JG</span>
+                <span class="user-profile__name">John Garcia</span>
+            </div>
         </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,10 @@
             </nav>
 
             <a class="cta-button" href="events.html">+ New Event</a>
+            <div class="user-profile" aria-label="Account menu">
+                <span class="user-profile__avatar" aria-hidden="true">JG</span>
+                <span class="user-profile__name">John Garcia</span>
+            </div>
         </div>
     </header>
 
@@ -38,7 +42,7 @@
         <section class="page-header">
             <div>
                 <p class="page-eyebrow">Dashboard</p>
-                <h1 class="page-title">Welcome back, Admin!</h1>
+                <h1 class="page-title">Welcome back, John Garcia!</h1>
                 <p class="lead-text">Stay ahead of every tasting, private party, and corporate gathering with a real-time pulse on staffing and logistics.</p>
             </div>
             <div class="hero-actions">

--- a/settings.html
+++ b/settings.html
@@ -31,6 +31,10 @@
             </nav>
 
             <a class="cta-button" href="events.html">+ New Event</a>
+            <div class="user-profile" aria-label="Account menu">
+                <span class="user-profile__avatar" aria-hidden="true">JG</span>
+                <span class="user-profile__name">John Garcia</span>
+            </div>
         </div>
     </header>
 

--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,37 @@ img {
   box-shadow: 0 16px 32px -12px rgba(249, 115, 22, 0.45);
 }
 
+.user-profile {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  font-weight: 600;
+  color: var(--slate-600);
+  white-space: nowrap;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.user-profile__avatar {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--primary-600);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.user-profile__name {
+  font-size: 0.9rem;
+}
+
 .mobile-nav-toggle {
   display: none;
   background: none;
@@ -679,6 +710,10 @@ textarea {
   }
 
   .cta-button {
+    display: none;
+  }
+
+  .user-profile {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- add a persistent John Garcia account pill to the header navigation on every page
- style the new account pill and initials avatar to match the existing UI, hiding it on mobile for spacing

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de1682ba1083339f201936380cebbf