### PR TITLE
Rewire scheduler pages to share a single storage service

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -50,114 +50,11 @@
         <section class="content-card">
             <div class="card-header">
                 <div>
-                    <h2 class="card-title">October 2025 overview</h2>
+                    <h2 class="card-title" id="calendarMonthHeading">Monthly overview</h2>
                     <p class="card-subtitle">Hover over a day to reveal assignments and prep checklists.</p>
                 </div>
             </div>
-            <div class="calendar-grid">
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 1</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 2</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 3</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 4</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 5</span>
-                    <div class="calendar-event">Corporate Party</div>
-                    <p class="card-subtitle">Call time 6:00 PM · 4 staff</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 6</span>
-                    <div class="calendar-event">Tasting Prep</div>
-                    <p class="card-subtitle">Inventory pull · Syrups ready</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 7</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 8</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 9</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 10</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 11</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 12</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 13</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 14</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 15</span>
-                    <div class="calendar-event">Wedding Reception</div>
-                    <p class="card-subtitle">Needs staffing</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 16</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 17</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 18</span>
-                    <div class="calendar-event">Mixology Workshop</div>
-                    <p class="card-subtitle">Priya · Jamie · 5:30 PM</p>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 19</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 20</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 21</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 22</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 23</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 24</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Thu 25</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Fri 26</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sat 27</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Sun 28</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Mon 29</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Tue 30</span>
-                </div>
-                <div class="calendar-cell">
-                    <span class="calendar-cell__date">Wed 31</span>
-                    <div class="calendar-event">Inventory Audit</div>
-                </div>
-            </div>
+            <div class="calendar-grid" id="calendarGrid"></div>
         </section>
 
         <section class="split-layout">
@@ -193,26 +90,7 @@
                                 <th>Prep hours</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            <tr>
-                                <td>Corporate Party</td>
-                                <td>120</td>
-                                <td>4</td>
-                                <td>6</td>
-                            </tr>
-                            <tr>
-                                <td>Wedding Reception</td>
-                                <td>180</td>
-                                <td>Pending</td>
-                                <td>8</td>
-                            </tr>
-                            <tr>
-                                <td>Mixology Workshop</td>
-                                <td>25</td>
-                                <td>2</td>
-                                <td>3</td>
-                            </tr>
-                        </tbody>
+                        <tbody id="weekSummaryTable"></tbody>
                     </table>
                 </div>
             </article>
@@ -221,6 +99,7 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
+    <script src="storage.js"></script>
     <script>
         const navToggle = document.getElementById('mobileNavToggle');
         const nav = document.getElementById('primaryNav');
@@ -230,6 +109,191 @@
                 nav.classList.toggle('open');
             });
         }
+
+        const store = window.B2UStore;
+        const calendarGrid = document.getElementById('calendarGrid');
+        const calendarHeading = document.getElementById('calendarMonthHeading');
+        const weekSummaryTable = document.getElementById('weekSummaryTable');
+
+        const weekdayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+        const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+
+        function getEventTimestamp(event) {
+            if (!event || !event.date) {
+                return Number.MAX_SAFE_INTEGER;
+            }
+
+            const timestamp = new Date(`${event.date}T${event.time || '00:00'}`).getTime();
+            return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+        }
+
+        function renderCalendar(events) {
+            if (!calendarGrid) {
+                return;
+            }
+
+            calendarGrid.innerHTML = '';
+
+            if (!store) {
+                const message = document.createElement('p');
+                message.className = 'empty-state';
+                message.textContent = 'Calendar data unavailable. Refresh to retry.';
+                calendarGrid.appendChild(message);
+                return;
+            }
+
+            const today = new Date();
+            const sorted = events.slice().sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b));
+            const firstUpcoming = sorted.find((event) => getEventTimestamp(event) !== Number.MAX_SAFE_INTEGER);
+            const referenceDate = firstUpcoming && firstUpcoming.date ? new Date(`${firstUpcoming.date}T00:00`) : today;
+
+            const year = referenceDate.getFullYear();
+            const month = referenceDate.getMonth();
+            const monthStart = new Date(year, month, 1);
+            const daysInMonth = new Date(year, month + 1, 0).getDate();
+            const leadingEmpty = monthStart.getDay();
+
+            if (calendarHeading) {
+                calendarHeading.textContent = `${monthFormatter.format(referenceDate)} overview`;
+            }
+
+            const eventsByDate = events.reduce((acc, event) => {
+                if (!event.date) {
+                    return acc;
+                }
+                (acc[event.date] = acc[event.date] || []).push(event);
+                return acc;
+            }, {});
+
+            for (let i = 0; i < leadingEmpty; i += 1) {
+                const emptyCell = document.createElement('div');
+                emptyCell.className = 'calendar-cell calendar-cell--empty';
+                calendarGrid.appendChild(emptyCell);
+            }
+
+            for (let day = 1; day <= daysInMonth; day += 1) {
+                const cellDate = new Date(year, month, day);
+                const isoDate = cellDate.toISOString().slice(0, 10);
+                const cell = document.createElement('div');
+                cell.className = 'calendar-cell';
+
+                if (cellDate.toDateString() === today.toDateString()) {
+                    cell.classList.add('calendar-cell--today');
+                }
+
+                const dateLabel = document.createElement('span');
+                dateLabel.className = 'calendar-cell__date';
+                dateLabel.textContent = `${weekdayFormatter.format(cellDate)} ${day}`;
+                cell.appendChild(dateLabel);
+
+                const dayEvents = eventsByDate[isoDate] || [];
+                dayEvents
+                    .slice()
+                    .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                    .forEach((event) => {
+                        const eventBlock = document.createElement('div');
+                        eventBlock.className = 'calendar-event';
+                        eventBlock.textContent = event.name;
+                        cell.appendChild(eventBlock);
+
+                        const details = document.createElement('p');
+                        details.className = 'card-subtitle';
+                        const time = event.time ? ` · ${event.time}` : '';
+                        const location = event.location ? ` · ${event.location}` : '';
+                        details.textContent = `${event.staffingStatus || 'Staffing pending'}${time}${location}`;
+                        cell.appendChild(details);
+                    });
+
+                calendarGrid.appendChild(cell);
+            }
+        }
+
+        function estimatePrepHours(event) {
+            if (!event) {
+                return 0;
+            }
+
+            const guests = event.guestCount || 0;
+            const base = guests ? Math.max(2, Math.ceil(guests / 40)) : 3;
+            return event.staffingLevel === 'success' ? base : base + 1;
+        }
+
+        function renderWeekSummary(events) {
+            if (!weekSummaryTable) {
+                return;
+            }
+
+            weekSummaryTable.innerHTML = '';
+
+            if (!store) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 4;
+                cell.className = 'empty-state';
+                cell.textContent = 'Unable to load weekly summary.';
+                row.appendChild(cell);
+                weekSummaryTable.appendChild(row);
+                return;
+            }
+
+            const now = Date.now();
+            const oneWeek = 1000 * 60 * 60 * 24 * 7;
+            const upcomingWeek = events
+                .slice()
+                .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                .filter((event) => {
+                    const timestamp = getEventTimestamp(event);
+                    return timestamp >= now && timestamp <= now + oneWeek;
+                })
+                .slice(0, 6);
+
+            if (upcomingWeek.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 4;
+                cell.className = 'empty-state';
+                cell.textContent = 'Nothing booked for the next seven days.';
+                row.appendChild(cell);
+                weekSummaryTable.appendChild(row);
+                return;
+            }
+
+            upcomingWeek.forEach((event) => {
+                const row = document.createElement('tr');
+
+                const nameCell = document.createElement('td');
+                nameCell.textContent = event.name;
+
+                const guestCell = document.createElement('td');
+                guestCell.textContent = event.guestCount ? event.guestCount : '—';
+
+                const teamCell = document.createElement('td');
+                teamCell.textContent = event.staffingStatus || 'Staffing pending';
+
+                const prepCell = document.createElement('td');
+                prepCell.textContent = estimatePrepHours(event);
+
+                row.appendChild(nameCell);
+                row.appendChild(guestCell);
+                row.appendChild(teamCell);
+                row.appendChild(prepCell);
+                weekSummaryTable.appendChild(row);
+            });
+        }
+
+        function renderCalendarPage() {
+            if (!store) {
+                renderCalendar([]);
+                renderWeekSummary([]);
+                return;
+            }
+
+            const events = store.getEvents();
+            renderCalendar(events);
+            renderWeekSummary(events);
+        }
+
+        renderCalendarPage();
     </script>
 </body>
 </html>

--- a/employees.html
+++ b/employees.html
@@ -50,18 +50,18 @@
         <section class="card-grid stats-grid">
             <article class="stat-card">
                 <span class="stat-card__label">Active staff</span>
-                <span class="stat-card__value">14</span>
-                <span class="stat-card__meta success">10 available this week</span>
+                <span class="stat-card__value" id="activeStaffStat">0</span>
+                <span class="stat-card__meta success" id="availableStaffMeta">0 available this week</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Roles covered</span>
-                <span class="stat-card__value" style="font-size:1.8rem;">5</span>
-                <span class="stat-card__meta">Bartenders, Mixologists, Leads…</span>
+                <span class="stat-card__value" id="rolesCoveredStat" style="font-size:1.8rem;">0</span>
+                <span class="stat-card__meta" id="rolesCoveredMeta">Add team members to broaden expertise.</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Upcoming PTO</span>
-                <span class="stat-card__value" style="color: var(--warning-500);">3</span>
-                <span class="stat-card__meta warning">Plan coverage</span>
+                <span class="stat-card__value" id="upcomingPtoStat" style="color: var(--warning-500);">0</span>
+                <span class="stat-card__meta warning" id="upcomingPtoMeta">Plan coverage</span>
             </article>
         </section>
 
@@ -72,38 +72,7 @@
                     <p class="card-subtitle">Search, sort, and understand everyone’s strengths at a glance.</p>
                 </div>
             </div>
-            <div class="list-grid">
-                <article class="person-card">
-                    <h3 class="person-card__name">John Doe</h3>
-                    <p class="person-card__role">Bar Lead · Flair certified</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Jane Smith</h3>
-                    <p class="person-card__role">Mixologist · Mocktail specialist</p>
-                    <div class="person-card__status"><span class="badge warning">On PTO</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Alex Rivera</h3>
-                    <p class="person-card__role">Bartender · Bilingual</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Priya Singh</h3>
-                    <p class="person-card__role">Mixology Lead · Seasonal menu</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Jamie Lee</h3>
-                    <p class="person-card__role">Support · Prep specialist</p>
-                    <div class="person-card__status"><span class="badge warning">Limited hours</span></div>
-                </article>
-                <article class="person-card">
-                    <h3 class="person-card__name">Marcus Allen</h3>
-                    <p class="person-card__role">Barback</p>
-                    <div class="person-card__status"><span class="badge success">Available</span></div>
-                </article>
-            </div>
+            <div class="list-grid" id="teamList"></div>
         </section>
 
         <section class="split-layout">
@@ -115,38 +84,7 @@
                     </div>
                     <a class="card-action" href="calendar.html">View schedule →</a>
                 </div>
-                <div class="timeline">
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">🍸</span>
-                            <div>
-                                <h3 class="person-card__name">Corporate Party</h3>
-                                <p class="card-subtitle">John Doe · Alex Rivera · Oct 5 · 6:00 PM call time</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta"><span class="badge success">Ready</span></span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">🥂</span>
-                            <div>
-                                <h3 class="person-card__name">Wedding Reception</h3>
-                                <p class="card-subtitle">Needs 2 bartenders · Oct 15</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta"><span class="badge warning">Staff</span></span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">📅</span>
-                            <div>
-                                <h3 class="person-card__name">Mixology Workshop</h3>
-                                <p class="card-subtitle">Priya Singh · Jamie Lee · Oct 18</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta"><span class="badge success">Confirmed</span></span>
-                    </div>
-                </div>
+                <div class="timeline" id="upcomingShifts"></div>
             </article>
 
             <article id="add-employee" class="content-card">
@@ -156,46 +94,58 @@
                         <p class="card-subtitle">Invite freelancers or seasonal staff to upcoming shifts.</p>
                     </div>
                 </div>
-                <form>
+                <form id="teamForm">
                     <div class="form-grid">
                         <div class="form-field">
                             <label for="teamName">Name</label>
-                            <input id="teamName" type="text" placeholder="Full name" />
+                            <input id="teamName" name="name" type="text" placeholder="Full name" required />
                         </div>
                         <div class="form-field">
                             <label for="teamRole">Role</label>
-                            <select id="teamRole">
-                                <option selected disabled>Select role</option>
+                            <select id="teamRole" name="role" required>
+                                <option value="" selected disabled>Select role</option>
                                 <option>Bartender</option>
                                 <option>Mixologist</option>
                                 <option>Bar Lead</option>
                                 <option>Support / Barback</option>
+                                <option>Event Captain</option>
                             </select>
                         </div>
                         <div class="form-field">
                             <label for="teamEmail">Email</label>
-                            <input id="teamEmail" type="email" placeholder="name@bartending2u.com" />
+                            <input id="teamEmail" name="email" type="email" placeholder="name@bartending2u.com" />
                         </div>
                         <div class="form-field">
                             <label for="teamPhone">Phone</label>
-                            <input id="teamPhone" type="tel" placeholder="(555) 123-4567" />
+                            <input id="teamPhone" name="phone" type="tel" placeholder="(555) 123-4567" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamStatus">Status</label>
+                            <select id="teamStatus" name="status" required>
+                                <option value="Available" data-level="success" selected>Available</option>
+                                <option value="On PTO" data-level="warning">On PTO</option>
+                                <option value="Limited hours" data-level="warning">Limited hours</option>
+                                <option value="Booked" data-level="danger">Booked</option>
+                            </select>
                         </div>
                     </div>
                     <div class="form-field">
                         <label for="teamNotes">Specialties & certifications</label>
-                        <textarea id="teamNotes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
+                        <textarea id="teamNotes" name="notes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
                     </div>
                     <div class="table-actions" style="justify-content: flex-end;">
                         <button class="button ghost" type="reset">Clear</button>
                         <button class="button primary" type="submit">Invite</button>
                     </div>
                 </form>
+
             </article>
         </section>
     </main>
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
+    <script src="storage.js"></script>
     <script>
         const navToggle = document.getElementById('mobileNavToggle');
         const nav = document.getElementById('primaryNav');
@@ -205,6 +155,287 @@
                 nav.classList.toggle('open');
             });
         }
+
+        const store = window.B2UStore;
+        const teamList = document.getElementById('teamList');
+        const teamForm = document.getElementById('teamForm');
+        const upcomingShifts = document.getElementById('upcomingShifts');
+
+        function createBadge(text, level) {
+            const badge = document.createElement('span');
+            badge.className = `badge ${level || 'neutral'}`;
+            badge.textContent = text;
+            return badge;
+        }
+
+        function getStatusLevel(value) {
+            if (!value) {
+                return 'neutral';
+            }
+            const normalized = value.toLowerCase();
+            if (normalized.includes('available') || normalized.includes('ready')) return 'success';
+            if (normalized.includes('pto') || normalized.includes('limited')) return 'warning';
+            if (normalized.includes('booked')) return 'danger';
+            return 'info';
+        }
+
+        function getEventTimestamp(event) {
+            if (!event || !event.date) {
+                return Number.MAX_SAFE_INTEGER;
+            }
+            const timestamp = new Date(`${event.date}T${event.time || '00:00'}`).getTime();
+            return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+        }
+
+        function formatEventDate(dateStr, timeStr) {
+            if (!dateStr) {
+                return 'Date TBC';
+            }
+            const date = new Date(`${dateStr}T${timeStr || '12:00'}`);
+            if (Number.isNaN(date.getTime())) {
+                return 'Date TBC';
+            }
+            return new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: timeStr ? 'numeric' : undefined,
+                minute: timeStr ? '2-digit' : undefined,
+            }).format(date);
+        }
+
+        function renderTeamList(employees) {
+            if (!teamList) {
+                return;
+            }
+
+            teamList.innerHTML = '';
+
+            if (!store) {
+                const message = document.createElement('p');
+                message.className = 'empty-state';
+                message.textContent = 'Unable to load staff directory. Refresh the page to retry.';
+                teamList.appendChild(message);
+                return;
+            }
+
+            if (employees.length === 0) {
+                const message = document.createElement('p');
+                message.className = 'empty-state';
+                message.textContent = 'Invite your first bartender or mixologist to build the roster.';
+                teamList.appendChild(message);
+                return;
+            }
+
+            employees
+                .slice()
+                .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+                .forEach((employee) => {
+                    const card = document.createElement('article');
+                    card.className = 'person-card';
+                    card.dataset.employeeId = employee.id;
+
+                    const name = document.createElement('h3');
+                    name.className = 'person-card__name';
+                    name.textContent = employee.name || 'Unnamed team member';
+
+                    const role = document.createElement('p');
+                    role.className = 'person-card__role';
+                    role.textContent = employee.role || 'Role pending';
+
+                    const statusWrapper = document.createElement('div');
+                    statusWrapper.className = 'person-card__status';
+                    statusWrapper.appendChild(createBadge(employee.status || 'Available', employee.statusLevel || getStatusLevel(employee.status)));
+
+                    card.appendChild(name);
+                    card.appendChild(role);
+                    card.appendChild(statusWrapper);
+
+                    const contactBits = [employee.email, employee.phone].filter(Boolean);
+                    if (contactBits.length) {
+                        const contact = document.createElement('p');
+                        contact.className = 'card-subtitle';
+                        contact.textContent = contactBits.join(' • ');
+                        card.appendChild(contact);
+                    }
+
+                    if (employee.notes) {
+                        const notes = document.createElement('p');
+                        notes.className = 'card-subtitle';
+                        notes.textContent = employee.notes;
+                        card.appendChild(notes);
+                    }
+
+                    const actions = document.createElement('div');
+                    actions.className = 'person-card__actions';
+                    const removeButton = document.createElement('button');
+                    removeButton.type = 'button';
+                    removeButton.className = 'card-action link-button';
+                    removeButton.dataset.removeEmployee = employee.id;
+                    removeButton.textContent = 'Remove';
+                    actions.appendChild(removeButton);
+                    card.appendChild(actions);
+
+                    teamList.appendChild(card);
+                });
+        }
+
+        function updateStats(employees) {
+            const activeStaff = document.getElementById('activeStaffStat');
+            const availableMeta = document.getElementById('availableStaffMeta');
+            const rolesStat = document.getElementById('rolesCoveredStat');
+            const rolesMeta = document.getElementById('rolesCoveredMeta');
+            const ptoStat = document.getElementById('upcomingPtoStat');
+            const ptoMeta = document.getElementById('upcomingPtoMeta');
+
+            const total = employees.length;
+            const available = employees.filter((employee) => (employee.statusLevel || getStatusLevel(employee.status)) === 'success').length;
+
+            const roles = new Set();
+            employees.forEach((employee) => {
+                if (employee.role) {
+                    const roleName = employee.role.split('·')[0].trim();
+                    roles.add(roleName);
+                }
+            });
+
+            const ptoCount = employees.filter((employee) => (employee.status || '').toLowerCase().includes('pto')).length;
+
+            if (activeStaff) {
+                activeStaff.textContent = total;
+            }
+            if (availableMeta) {
+                availableMeta.textContent = `${available} available this week`;
+            }
+            if (rolesStat) {
+                rolesStat.textContent = roles.size;
+            }
+            if (rolesMeta) {
+                rolesMeta.textContent = roles.size ? Array.from(roles).join(', ') : 'Add team members to broaden expertise.';
+            }
+            if (ptoStat) {
+                ptoStat.textContent = ptoCount;
+            }
+            if (ptoMeta) {
+                ptoMeta.textContent = ptoCount ? 'Coordinate coverage for upcoming absences.' : 'All clear for now.';
+            }
+        }
+
+        function renderUpcomingShifts(events) {
+            if (!upcomingShifts) {
+                return;
+            }
+
+            upcomingShifts.innerHTML = '';
+
+            if (!store) {
+                const message = document.createElement('p');
+                message.className = 'empty-state';
+                message.textContent = 'Unable to load schedule previews.';
+                upcomingShifts.appendChild(message);
+                return;
+            }
+
+            const upcomingEvents = events
+                .slice()
+                .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                .filter((event) => getEventTimestamp(event) >= Date.now())
+                .slice(0, 4);
+
+            if (upcomingEvents.length === 0) {
+                const message = document.createElement('p');
+                message.className = 'empty-state';
+                message.textContent = 'Schedule a new event to see staffing assignments here.';
+                upcomingShifts.appendChild(message);
+                return;
+            }
+
+            upcomingEvents.forEach((event) => {
+                const item = document.createElement('div');
+                item.className = 'timeline-item';
+
+                const left = document.createElement('div');
+                left.className = 'timeline-item__left';
+
+                const icon = document.createElement('span');
+                icon.className = 'timeline-icon';
+                icon.textContent = '🍸';
+                left.appendChild(icon);
+
+                const copy = document.createElement('div');
+                const title = document.createElement('h3');
+                title.className = 'person-card__name';
+                title.textContent = event.name;
+                const subtitle = document.createElement('p');
+                subtitle.className = 'card-subtitle';
+                const location = event.location ? ` · ${event.location}` : '';
+                subtitle.textContent = `${formatEventDate(event.date, event.time)}${location}`;
+                copy.appendChild(title);
+                copy.appendChild(subtitle);
+                left.appendChild(copy);
+
+                const meta = document.createElement('span');
+                meta.className = 'timeline-item__meta';
+                meta.appendChild(createBadge(event.staffingStatus || 'Staffing pending', event.staffingLevel || getStatusLevel(event.staffingStatus)));
+
+                item.appendChild(left);
+                item.appendChild(meta);
+                upcomingShifts.appendChild(item);
+            });
+        }
+
+        function refresh() {
+            if (!store) {
+                renderTeamList([]);
+                renderUpcomingShifts([]);
+                updateStats([]);
+                return;
+            }
+
+            const employees = store.getEmployees();
+            const events = store.getEvents();
+            renderTeamList(employees);
+            updateStats(employees);
+            renderUpcomingShifts(events);
+        }
+
+        if (teamList) {
+            teamList.addEventListener('click', (event) => {
+                const target = event.target.closest('[data-remove-employee]');
+                if (!target || !store) {
+                    return;
+                }
+
+                store.removeEmployee(target.dataset.removeEmployee);
+                refresh();
+            });
+        }
+
+        if (teamForm && store) {
+            teamForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+
+                const data = new FormData(teamForm);
+                const statusOption = teamForm.teamStatus.options[teamForm.teamStatus.selectedIndex];
+
+                store.addEmployee({
+                    name: (data.get('name') || '').trim() || 'Unnamed team member',
+                    role: data.get('role') || '',
+                    email: (data.get('email') || '').trim(),
+                    phone: (data.get('phone') || '').trim(),
+                    status: data.get('status') || 'Available',
+                    statusLevel: statusOption ? statusOption.dataset.level : undefined,
+                    notes: (data.get('notes') || '').trim(),
+                });
+
+                teamForm.reset();
+                if (teamForm.teamStatus) {
+                    teamForm.teamStatus.value = 'Available';
+                }
+                refresh();
+            });
+        }
+
+        refresh();
     </script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -55,10 +55,10 @@
                 </div>
             </div>
             <div class="tab-bar">
-                <button class="tab active" type="button">All</button>
-                <button class="tab" type="button">Confirmed</button>
-                <button class="tab" type="button">Pending</button>
-                <button class="tab" type="button">Drafts</button>
+                <button class="tab active" type="button" data-filter="all">All</button>
+                <button class="tab" type="button" data-filter="confirmed">Confirmed</button>
+                <button class="tab" type="button" data-filter="pending">Pending</button>
+                <button class="tab" type="button" data-filter="drafts">Drafts</button>
             </div>
             <div class="table-wrapper">
                 <table>
@@ -73,56 +73,7 @@
                             <th>Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <tr>
-                            <td>Corporate Party</td>
-                            <td>Oct 5, 2025</td>
-                            <td>Downtown Houston</td>
-                            <td>Signature Cocktail Bar</td>
-                            <td><span class="badge success">Confirmed</span></td>
-                            <td><span class="badge success">Fully staffed</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">View</a>
-                                <a class="card-action" href="#">Staff</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Wedding Reception</td>
-                            <td>Oct 15, 2025</td>
-                            <td>The Grand Hall</td>
-                            <td>Premium Mixology</td>
-                            <td><span class="badge warning">Awaiting deposit</span></td>
-                            <td><span class="badge warning">Needs 2 bartenders</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Send reminder</a>
-                                <a class="card-action" href="#">Assign</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Holiday Gala</td>
-                            <td>Nov 30, 2025</td>
-                            <td>Skyline Ballroom</td>
-                            <td>Craft Experience</td>
-                            <td><span class="badge danger">Contract overdue</span></td>
-                            <td><span class="badge warning">Partial coverage</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Follow up</a>
-                                <a class="card-action" href="#">View notes</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Mixology Workshop</td>
-                            <td>Dec 3, 2025</td>
-                            <td>Private Residence</td>
-                            <td>Interactive Class</td>
-                            <td><span class="badge success">Confirmed</span></td>
-                            <td><span class="badge success">Ready</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="#">Checklist</a>
-                                <a class="card-action" href="#">Prep sheet</a>
-                            </td>
-                        </tr>
-                    </tbody>
+                    <tbody id="eventsTableBody"></tbody>
                 </table>
             </div>
         </section>
@@ -134,28 +85,28 @@
                     <p class="card-subtitle">Capture the essentials, assign talent, and keep clients delighted.</p>
                 </div>
             </div>
-            <form>
+            <form id="eventForm">
                 <div class="form-grid">
                     <div class="form-field">
                         <label for="eventName">Event name</label>
-                        <input id="eventName" type="text" placeholder="E.g. Winter Soirée" />
+                        <input id="eventName" name="name" type="text" placeholder="E.g. Winter Soirée" required />
                     </div>
                     <div class="form-field">
                         <label for="eventDate">Date</label>
-                        <input id="eventDate" type="date" />
+                        <input id="eventDate" name="date" type="date" required />
                     </div>
                     <div class="form-field">
                         <label for="eventTime">Start time</label>
-                        <input id="eventTime" type="time" />
+                        <input id="eventTime" name="time" type="time" />
                     </div>
                     <div class="form-field">
                         <label for="eventLocation">Location</label>
-                        <input id="eventLocation" type="text" placeholder="Venue or address" />
+                        <input id="eventLocation" name="location" type="text" placeholder="Venue or address" />
                     </div>
                     <div class="form-field">
                         <label for="eventPackage">Service package</label>
-                        <select id="eventPackage">
-                            <option selected disabled>Select package</option>
+                        <select id="eventPackage" name="package" required>
+                            <option value="" selected disabled>Select package</option>
                             <option>Signature Cocktail Bar</option>
                             <option>Premium Mixology</option>
                             <option>Interactive Workshop</option>
@@ -164,12 +115,40 @@
                     </div>
                     <div class="form-field">
                         <label for="guestCount">Guest count</label>
-                        <input id="guestCount" type="number" min="0" placeholder="Expected attendees" />
+                        <input id="guestCount" name="guestCount" type="number" min="0" placeholder="Expected attendees" />
+                    </div>
+                    <div class="form-field">
+                        <label for="eventPayout">Estimated payout (USD)</label>
+                        <input id="eventPayout" name="payout" type="number" min="0" step="50" placeholder="0" />
+                    </div>
+                </div>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <label for="eventStatus">Event status</label>
+                        <select id="eventStatus" name="status" required>
+                            <option value="" disabled>Select status</option>
+                            <option value="Confirmed" data-level="success" selected>Confirmed</option>
+                            <option value="Awaiting deposit" data-level="warning">Awaiting deposit</option>
+                            <option value="Contract overdue" data-level="danger">Contract overdue</option>
+                            <option value="Proposal sent" data-level="info">Proposal sent</option>
+                            <option value="Draft" data-level="neutral">Draft</option>
+                        </select>
+                    </div>
+                    <div class="form-field">
+                        <label for="eventStaffing">Staffing status</label>
+                        <select id="eventStaffing" name="staffingStatus" required>
+                            <option value="" disabled>Select staffing</option>
+                            <option value="Fully staffed" data-level="success" selected>Fully staffed</option>
+                            <option value="Ready" data-level="success">Ready</option>
+                            <option value="Needs 1 bartender" data-level="warning">Needs 1 bartender</option>
+                            <option value="Needs 2 bartenders" data-level="warning">Needs 2 bartenders</option>
+                            <option value="Unassigned" data-level="danger">Unassigned</option>
+                        </select>
                     </div>
                 </div>
                 <div class="form-field">
                     <label for="eventNotes">Notes & client preferences</label>
-                    <textarea id="eventNotes" placeholder="Share tastings, specialty cocktails, or logistics." ></textarea>
+                    <textarea id="eventNotes" name="notes" placeholder="Share tastings, specialty cocktails, or logistics."></textarea>
                 </div>
                 <div class="table-actions" style="justify-content: flex-end;">
                     <button class="button ghost" type="reset">Clear</button>
@@ -181,6 +160,7 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
+    <script src="storage.js"></script>
     <script>
         const navToggle = document.getElementById('mobileNavToggle');
         const nav = document.getElementById('primaryNav');
@@ -191,13 +171,226 @@
             });
         }
 
+        const store = window.B2UStore;
+        const tableBody = document.getElementById('eventsTableBody');
+        const form = document.getElementById('eventForm');
         const tabs = document.querySelectorAll('.tab');
-        tabs.forEach((tab) => {
-            tab.addEventListener('click', () => {
-                tabs.forEach((button) => button.classList.remove('active'));
-                tab.classList.add('active');
+        let activeFilter = 'all';
+
+        function formatDate(dateStr, timeStr) {
+            if (!dateStr) {
+                return 'Date TBC';
+            }
+
+            const date = new Date(`${dateStr}T${timeStr || '12:00'}`);
+            if (Number.isNaN(date.getTime())) {
+                return 'Date TBC';
+            }
+
+            return new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                hour: timeStr ? 'numeric' : undefined,
+                minute: timeStr ? '2-digit' : undefined,
+            }).format(date);
+        }
+
+        function formatCurrency(amount) {
+            if (!amount && amount !== 0) {
+                return '$0';
+            }
+
+            return new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'USD',
+                maximumFractionDigits: 0,
+            }).format(amount);
+        }
+
+        function createBadge(text, level) {
+            const badge = document.createElement('span');
+            badge.className = `badge ${level || 'neutral'}`;
+            badge.textContent = text;
+            return badge;
+        }
+
+        function getEventTimestamp(event) {
+            if (!event || !event.date) {
+                return Number.MAX_SAFE_INTEGER;
+            }
+
+            const timestamp = new Date(`${event.date}T${event.time || '00:00'}`).getTime();
+            return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+        }
+
+        function filterEvents(events) {
+            switch (activeFilter) {
+                case 'confirmed':
+                    return events.filter((event) => event.statusLevel === 'success');
+                case 'pending':
+                    return events.filter((event) => event.statusLevel !== 'success');
+                case 'drafts':
+                    return events.filter((event) => (event.status || '').toLowerCase().includes('draft'));
+                default:
+                    return events;
+            }
+        }
+
+        function renderEvents() {
+            if (!tableBody) {
+                return;
+            }
+
+            tableBody.innerHTML = '';
+
+            if (!store) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 7;
+                cell.className = 'empty-state';
+                cell.textContent = 'Storage service unavailable. Refresh to retry.';
+                row.appendChild(cell);
+                tableBody.appendChild(row);
+                return;
+            }
+
+            const events = filterEvents(
+                store
+                    .getEvents()
+                    .slice()
+                    .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+            );
+
+            if (events.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 7;
+                cell.className = 'empty-state';
+                cell.textContent = 'No events match this filter yet. Save one below to get started.';
+                row.appendChild(cell);
+                tableBody.appendChild(row);
+                return;
+            }
+
+            events.forEach((event) => {
+                const row = document.createElement('tr');
+
+                const nameCell = document.createElement('td');
+                nameCell.textContent = event.name;
+
+                const dateCell = document.createElement('td');
+                dateCell.textContent = formatDate(event.date, event.time);
+
+                const locationCell = document.createElement('td');
+                locationCell.textContent = event.location || 'Location TBC';
+
+                const packageCell = document.createElement('td');
+                const packageParts = [];
+                if (event.package) {
+                    packageParts.push(event.package);
+                }
+                if (event.guestCount) {
+                    packageParts.push(`${event.guestCount} guests`);
+                }
+                if (event.payout) {
+                    packageParts.push(formatCurrency(event.payout));
+                }
+                packageCell.textContent = packageParts.join(' · ') || 'Package TBC';
+
+                const statusCell = document.createElement('td');
+                statusCell.appendChild(createBadge(event.status || 'Pending', event.statusLevel));
+
+                const staffingCell = document.createElement('td');
+                staffingCell.appendChild(createBadge(event.staffingStatus || 'Unassigned', event.staffingLevel));
+
+                const actionsCell = document.createElement('td');
+                actionsCell.className = 'table-actions';
+
+                const viewLink = document.createElement('a');
+                viewLink.className = 'card-action';
+                viewLink.href = '#new-event';
+                viewLink.textContent = 'View';
+
+                const removeButton = document.createElement('button');
+                removeButton.type = 'button';
+                removeButton.className = 'card-action link-button';
+                removeButton.dataset.removeEvent = event.id;
+                removeButton.textContent = 'Remove';
+
+                actionsCell.appendChild(viewLink);
+                actionsCell.appendChild(removeButton);
+
+                row.appendChild(nameCell);
+                row.appendChild(dateCell);
+                row.appendChild(locationCell);
+                row.appendChild(packageCell);
+                row.appendChild(statusCell);
+                row.appendChild(staffingCell);
+                row.appendChild(actionsCell);
+                tableBody.appendChild(row);
             });
-        });
+        }
+
+        if (tabs.length) {
+            tabs.forEach((tab) => {
+                tab.addEventListener('click', () => {
+                    tabs.forEach((button) => button.classList.remove('active'));
+                    tab.classList.add('active');
+                    activeFilter = tab.dataset.filter || 'all';
+                    renderEvents();
+                });
+            });
+        }
+
+        if (tableBody) {
+            tableBody.addEventListener('click', (event) => {
+                const target = event.target.closest('[data-remove-event]');
+                if (!target || !store) {
+                    return;
+                }
+
+                store.removeEvent(target.dataset.removeEvent);
+                renderEvents();
+            });
+        }
+
+        if (form && store) {
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+
+                const formData = new FormData(form);
+                const statusOption = form.eventStatus.options[form.eventStatus.selectedIndex];
+                const staffingOption = form.eventStaffing.options[form.eventStaffing.selectedIndex];
+
+                const eventPayload = {
+                    name: (formData.get('name') || '').trim() || 'Untitled event',
+                    date: formData.get('date') || '',
+                    time: formData.get('time') || '',
+                    location: (formData.get('location') || '').trim(),
+                    package: formData.get('package') || '',
+                    guestCount: Number(formData.get('guestCount') || 0),
+                    payout: Number(formData.get('payout') || 0),
+                    status: formData.get('status') || 'Draft',
+                    statusLevel: statusOption ? statusOption.dataset.level : undefined,
+                    staffingStatus: formData.get('staffingStatus') || 'Unassigned',
+                    staffingLevel: staffingOption ? staffingOption.dataset.level : undefined,
+                    notes: (formData.get('notes') || '').trim(),
+                };
+
+                store.addEvent(eventPayload);
+                form.reset();
+                if (form.eventStatus) {
+                    form.eventStatus.value = 'Confirmed';
+                }
+                if (form.eventStaffing) {
+                    form.eventStaffing.value = 'Fully staffed';
+                }
+                renderEvents();
+            });
+        }
+
+        renderEvents();
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,22 +50,22 @@
         <section class="card-grid stats-grid">
             <article class="stat-card">
                 <span class="stat-card__label">Total events</span>
-                <span class="stat-card__value">12</span>
+                <span class="stat-card__value" id="totalEventsStat">0</span>
                 <span class="stat-card__meta success">+2 vs last week</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Team availability</span>
-                <span class="stat-card__value">8 / 10</span>
-                <span class="stat-card__meta warning">2 on PTO</span>
+                <span class="stat-card__value" id="teamAvailabilityStat">0 / 0</span>
+                <span class="stat-card__meta warning">Live availability updates</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Next event</span>
-                <span class="stat-card__value" style="font-size:1.6rem;">Corporate Party</span>
-                <span class="stat-card__meta">Oct 5 · 7:00 PM</span>
+                <span class="stat-card__value" id="nextEventName" style="font-size:1.6rem;">No events scheduled</span>
+                <span class="stat-card__meta" id="nextEventMeta">Add an event to build your schedule.</span>
             </article>
             <article class="stat-card">
                 <span class="stat-card__label">Action needed</span>
-                <span class="stat-card__value" style="color: var(--danger-500);">3</span>
+                <span class="stat-card__value" id="actionNeededStat" style="color: var(--danger-500);">0</span>
                 <span class="stat-card__meta danger">Unassigned shifts</span>
             </article>
         </section>
@@ -79,48 +79,7 @@
                     </div>
                     <a class="card-action" href="events.html">View all activity →</a>
                 </div>
-                <div class="timeline">
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">✅</span>
-                            <div>
-                                <h3 class="person-card__name">Wedding Reception booked</h3>
-                                <p class="card-subtitle">Oct 15 · The Grand Hall · Deposit received</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">2 minutes ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">👤</span>
-                            <div>
-                                <h3 class="person-card__name">John Doe assigned</h3>
-                                <p class="card-subtitle">Corporate Party · Bar Lead confirmed</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">1 hour ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">📝</span>
-                            <div>
-                                <h3 class="person-card__name">Availability updated</h3>
-                                <p class="card-subtitle">Jane Smith marked unavailable on Nov 1</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">4 hours ago</span>
-                    </div>
-                    <div class="timeline-item">
-                        <div class="timeline-item__left">
-                            <span class="timeline-icon">📦</span>
-                            <div>
-                                <h3 class="person-card__name">Inventory check</h3>
-                                <p class="card-subtitle">Glassware restocked · Ready for tasting events</p>
-                            </div>
-                        </div>
-                        <span class="timeline-item__meta">Yesterday</span>
-                    </div>
-                </div>
+                <div class="timeline" id="activityFeed"></div>
             </article>
 
             <article class="content-card">
@@ -138,7 +97,7 @@
                         </button>
                         <div class="accordion-content" id="alert-1" data-open="true">
                             <div class="accordion-content__inner">
-                                <p>Assign barbacks for the Corporate Party cocktail hour. Current schedule has no coverage from 6–7 PM.</p>
+                                <ul id="staffingAlertsList" class="alert-list"></ul>
                                 <a class="card-action" href="employees.html">Review available team →</a>
                             </div>
                         </div>
@@ -191,38 +150,7 @@
                             <th>Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <tr>
-                            <td>Corporate Party</td>
-                            <td>Oct 5, 2025 · 7:00 PM</td>
-                            <td>Downtown Houston</td>
-                            <td>John D., Alex R.</td>
-                            <td><span class="badge success">Ready</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="events.html">View details</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Wedding Reception</td>
-                            <td>Oct 15, 2025 · 6:00 PM</td>
-                            <td>The Grand Hall</td>
-                            <td>Pending assignments</td>
-                            <td><span class="badge warning">Needs staffing</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="employees.html">Assign team</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Mixology Workshop</td>
-                            <td>Oct 18, 2025 · 5:30 PM</td>
-                            <td>Private Residence</td>
-                            <td>Jamie L., Priya S.</td>
-                            <td><span class="badge success">Confirmed</span></td>
-                            <td class="table-actions">
-                                <a class="card-action" href="events.html">Manage</a>
-                            </td>
-                        </tr>
-                    </tbody>
+                    <tbody id="dashboardEventsTable"></tbody>
                 </table>
             </div>
         </section>
@@ -230,6 +158,7 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
 
+    <script src="storage.js"></script>
     <script>
         const navToggle = document.getElementById('mobileNavToggle');
         const nav = document.getElementById('primaryNav');
@@ -261,6 +190,285 @@
                 }
             });
         });
+
+        const store = window.B2UStore;
+
+        function formatDateTime(dateStr, timeStr) {
+            if (!dateStr) {
+                return 'Date TBC';
+            }
+
+            const safeTime = timeStr ? timeStr : '12:00';
+            const date = new Date(`${dateStr}T${safeTime}`);
+            const dateFormatter = new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+            });
+            const timeFormatter = new Intl.DateTimeFormat('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+            });
+
+            return `${dateFormatter.format(date)} · ${timeFormatter.format(date)}`;
+        }
+
+        function formatDateOnly(dateStr) {
+            if (!dateStr) {
+                return 'Date TBC';
+            }
+            const date = new Date(`${dateStr}T12:00`);
+            return new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+            }).format(date);
+        }
+
+        function formatCurrency(amount) {
+            if (!amount && amount !== 0) {
+                return '$0';
+            }
+            return new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'USD',
+                maximumFractionDigits: 0,
+            }).format(amount);
+        }
+
+        function formatRelativeTime(timestamp) {
+            if (!timestamp) {
+                return '';
+            }
+
+            const diffMs = Date.now() - timestamp;
+            const minutes = Math.floor(diffMs / (1000 * 60));
+            if (minutes < 1) return 'Just now';
+            if (minutes < 60) return `${minutes} min ago`;
+            const hours = Math.floor(minutes / 60);
+            if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+            const days = Math.floor(hours / 24);
+            if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+            return formatDateOnly(new Date(timestamp).toISOString().slice(0, 10));
+        }
+
+        function getEventTimestamp(event) {
+            if (!event || !event.date) {
+                return Number.MAX_SAFE_INTEGER;
+            }
+
+            const timestamp = new Date(`${event.date}T${event.time || '00:00'}`).getTime();
+            return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+        }
+
+        function createBadge(text, level) {
+            const badge = document.createElement('span');
+            badge.className = `badge ${level || 'neutral'}`;
+            badge.textContent = text;
+            return badge;
+        }
+
+        function renderActivity(events, employees) {
+            const feed = document.getElementById('activityFeed');
+            if (!feed) {
+                return;
+            }
+
+            feed.innerHTML = '';
+
+            const activityItems = [
+                ...events.map((event) => ({
+                    id: event.id,
+                    createdAt: event.createdAt || 0,
+                    icon: '🍸',
+                    title: `${event.name} saved`,
+                    subtitle: `${formatDateTime(event.date, event.time)} · ${event.location || 'Location TBC'}`,
+                })),
+                ...employees.map((employee) => ({
+                    id: employee.id,
+                    createdAt: employee.createdAt || 0,
+                    icon: '👤',
+                    title: `${employee.name} added`,
+                    subtitle: `${employee.role || 'Role pending'} · ${employee.status || 'Status pending'}`,
+                })),
+            ]
+                .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))
+                .slice(0, 6);
+
+            if (activityItems.length === 0) {
+                const empty = document.createElement('p');
+                empty.className = 'empty-state';
+                empty.textContent = 'Activities will appear here after you add events or employees.';
+                feed.appendChild(empty);
+                return;
+            }
+
+            activityItems.forEach((item) => {
+                const timelineItem = document.createElement('div');
+                timelineItem.className = 'timeline-item';
+
+                const left = document.createElement('div');
+                left.className = 'timeline-item__left';
+
+                const icon = document.createElement('span');
+                icon.className = 'timeline-icon';
+                icon.textContent = item.icon;
+                left.appendChild(icon);
+
+                const copy = document.createElement('div');
+                const title = document.createElement('h3');
+                title.className = 'person-card__name';
+                title.textContent = item.title;
+                const subtitle = document.createElement('p');
+                subtitle.className = 'card-subtitle';
+                subtitle.textContent = item.subtitle;
+                copy.appendChild(title);
+                copy.appendChild(subtitle);
+                left.appendChild(copy);
+
+                const meta = document.createElement('span');
+                meta.className = 'timeline-item__meta';
+                meta.textContent = formatRelativeTime(item.createdAt);
+
+                timelineItem.appendChild(left);
+                timelineItem.appendChild(meta);
+                feed.appendChild(timelineItem);
+            });
+        }
+
+        function renderDashboardEvents(events) {
+            const tableBody = document.getElementById('dashboardEventsTable');
+            if (!tableBody) {
+                return;
+            }
+
+            tableBody.innerHTML = '';
+
+            if (events.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 6;
+                cell.className = 'empty-state';
+                cell.textContent = 'Log your first event to build this view.';
+                row.appendChild(cell);
+                tableBody.appendChild(row);
+                return;
+            }
+
+            events.slice(0, 5).forEach((event) => {
+                const row = document.createElement('tr');
+
+                const nameCell = document.createElement('td');
+                nameCell.textContent = event.name;
+
+                const dateCell = document.createElement('td');
+                dateCell.textContent = formatDateTime(event.date, event.time);
+
+                const locationCell = document.createElement('td');
+                locationCell.textContent = event.location || 'Location TBC';
+
+                const teamCell = document.createElement('td');
+                teamCell.textContent = event.staffingStatus || 'Staffing pending';
+
+                const statusCell = document.createElement('td');
+                statusCell.appendChild(createBadge(event.status || 'Pending', event.statusLevel));
+
+                const actionsCell = document.createElement('td');
+                actionsCell.className = 'table-actions';
+                const link = document.createElement('a');
+                link.className = 'card-action';
+                link.href = 'events.html';
+                link.textContent = 'View details';
+                actionsCell.appendChild(link);
+
+                row.appendChild(nameCell);
+                row.appendChild(dateCell);
+                row.appendChild(locationCell);
+                row.appendChild(teamCell);
+                row.appendChild(statusCell);
+                row.appendChild(actionsCell);
+                tableBody.appendChild(row);
+            });
+        }
+
+        function renderStaffingAlerts(events) {
+            const alertsList = document.getElementById('staffingAlertsList');
+            if (!alertsList) {
+                return;
+            }
+
+            alertsList.innerHTML = '';
+            const needsAttention = events.filter((event) => event.staffingLevel !== 'success');
+
+            if (needsAttention.length === 0) {
+                const item = document.createElement('li');
+                item.textContent = 'All events are fully staffed. Great job!';
+                alertsList.appendChild(item);
+                return;
+            }
+
+            needsAttention.forEach((event) => {
+                const item = document.createElement('li');
+                item.innerHTML = `<strong>${event.name}</strong> · ${event.staffingStatus || 'Staffing pending'} · ${formatDateOnly(event.date)}`;
+                alertsList.appendChild(item);
+            });
+        }
+
+        function updateStats(events, employees) {
+            const totalEvents = document.getElementById('totalEventsStat');
+            const teamAvailability = document.getElementById('teamAvailabilityStat');
+            const nextEventName = document.getElementById('nextEventName');
+            const nextEventMeta = document.getElementById('nextEventMeta');
+            const actionNeeded = document.getElementById('actionNeededStat');
+
+            if (totalEvents) {
+                totalEvents.textContent = events.length;
+            }
+
+            if (teamAvailability) {
+                const available = employees.filter((employee) => employee.statusLevel === 'success').length;
+                teamAvailability.textContent = `${available} / ${employees.length}`;
+            }
+
+            if (actionNeeded) {
+                const needsStaff = events.filter((event) => event.staffingLevel !== 'success').length;
+                actionNeeded.textContent = needsStaff;
+            }
+
+            if (nextEventName && nextEventMeta) {
+                const upcoming = events
+                    .slice()
+                    .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                    .find((event) => getEventTimestamp(event) >= Date.now());
+
+                if (upcoming) {
+                    nextEventName.textContent = upcoming.name;
+                    nextEventMeta.textContent = `${formatDateTime(upcoming.date, upcoming.time)} · ${formatCurrency(upcoming.payout || 0)}`;
+                } else if (events.length > 0) {
+                    const latest = events
+                        .slice()
+                        .sort((a, b) => getEventTimestamp(b) - getEventTimestamp(a))[0];
+                    nextEventName.textContent = latest.name;
+                    nextEventMeta.textContent = `${formatDateTime(latest.date, latest.time)} · Completed`;
+                } else {
+                    nextEventName.textContent = 'No events scheduled';
+                    nextEventMeta.textContent = 'Add an event to build your schedule.';
+                }
+            }
+        }
+
+        if (store) {
+            const events = store.getEvents();
+            const employees = store.getEmployees();
+            renderActivity(events, employees);
+            renderDashboardEvents(
+                events
+                    .slice()
+                    .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+            );
+            renderStaffingAlerts(events);
+            updateStats(events, employees);
+        }
     </script>
 </body>
 </html>

--- a/storage.js
+++ b/storage.js
@@ -171,7 +171,14 @@
             try {
                 const raw = global.localStorage.getItem(STORAGE_KEY);
                 if (!raw) {
-                    cache = clone(defaultData);
+                    const seeded = clone(defaultData);
+                    cache = seeded;
+                    try {
+                        global.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
+                    } catch (seedError) {
+                        console.warn('Unable to seed scheduler data to localStorage. Falling back to memory store.', seedError);
+                        memoryStore = clone(seeded);
+                    }
                     return cache;
                 }
 
@@ -212,16 +219,10 @@
             return clone(defaultData);
         }
 
-        const normalised = {
-            events: Array.isArray(data.events) ? data.events : [],
-            employees: Array.isArray(data.employees) ? data.employees : [],
+        return {
+            events: Array.isArray(data.events) ? data.events : clone(defaultData.events),
+            employees: Array.isArray(data.employees) ? data.employees : clone(defaultData.employees),
         };
-
-        if (normalised.events.length === 0 && normalised.employees.length === 0) {
-            return clone(defaultData);
-        }
-
-        return normalised;
     }
 
     function generateId(prefix) {

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,324 @@
+(function (global) {
+    const STORAGE_KEY = 'bartending2u-scheduler';
+
+    const defaultData = {
+        events: [
+            {
+                id: 'evt-1',
+                name: 'Corporate Party',
+                date: '2025-10-05',
+                time: '19:00',
+                location: 'Downtown Houston',
+                package: 'Signature Cocktail Bar',
+                guestCount: 120,
+                payout: 3800,
+                status: 'Confirmed',
+                statusLevel: 'success',
+                staffingStatus: 'Fully staffed',
+                staffingLevel: 'success',
+                notes: 'Deposit received. Call time 6:00 PM.',
+                createdAt: Date.now() - 1000 * 60 * 20,
+            },
+            {
+                id: 'evt-2',
+                name: 'Wedding Reception',
+                date: '2025-10-15',
+                time: '18:30',
+                location: 'The Grand Hall',
+                package: 'Premium Mixology',
+                guestCount: 180,
+                payout: 5200,
+                status: 'Awaiting deposit',
+                statusLevel: 'warning',
+                staffingStatus: 'Needs 2 bartenders',
+                staffingLevel: 'warning',
+                notes: 'Send reminder for deposit. Discuss signature cocktail list.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 3,
+            },
+            {
+                id: 'evt-3',
+                name: 'Holiday Gala',
+                date: '2025-11-30',
+                time: '20:00',
+                location: 'Skyline Ballroom',
+                package: 'Craft Experience',
+                guestCount: 250,
+                payout: 7600,
+                status: 'Contract overdue',
+                statusLevel: 'danger',
+                staffingStatus: 'Partial coverage',
+                staffingLevel: 'warning',
+                notes: 'Client reviewing updated package. Follow up Friday.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 10,
+            },
+            {
+                id: 'evt-4',
+                name: 'Mixology Workshop',
+                date: '2025-12-03',
+                time: '17:30',
+                location: 'Private Residence',
+                package: 'Interactive Workshop',
+                guestCount: 25,
+                payout: 1400,
+                status: 'Confirmed',
+                statusLevel: 'success',
+                staffingStatus: 'Ready',
+                staffingLevel: 'success',
+                notes: 'Include mocktail options and allergy-friendly mixers.',
+                createdAt: Date.now() - 1000 * 60 * 5,
+            },
+        ],
+        employees: [
+            {
+                id: 'emp-1',
+                name: 'John Doe',
+                role: 'Bar Lead · Flair certified',
+                email: 'john.doe@bartending2u.com',
+                phone: '(555) 100-2000',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Expert in corporate activations.',
+                createdAt: Date.now() - 1000 * 60 * 60,
+            },
+            {
+                id: 'emp-2',
+                name: 'Jane Smith',
+                role: 'Mixologist · Mocktail specialist',
+                email: 'jane.smith@bartending2u.com',
+                phone: '(555) 222-3333',
+                status: 'On PTO',
+                statusLevel: 'warning',
+                notes: 'Out Oct 10 - Oct 16.',
+                createdAt: Date.now() - 1000 * 60 * 60 * 2,
+            },
+            {
+                id: 'emp-3',
+                name: 'Alex Rivera',
+                role: 'Bartender · Bilingual',
+                email: 'alex.rivera@bartending2u.com',
+                phone: '(555) 444-5555',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Spanish/English. Comfortable with large crowds.',
+                createdAt: Date.now() - 1000 * 60 * 25,
+            },
+            {
+                id: 'emp-4',
+                name: 'Priya Singh',
+                role: 'Mixology Lead · Seasonal menu',
+                email: 'priya.singh@bartending2u.com',
+                phone: '(555) 777-8888',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Specializes in custom experiences.',
+                createdAt: Date.now() - 1000 * 60 * 15,
+            },
+            {
+                id: 'emp-5',
+                name: 'Jamie Lee',
+                role: 'Support · Prep specialist',
+                email: 'jamie.lee@bartending2u.com',
+                phone: '(555) 999-1212',
+                status: 'Limited hours',
+                statusLevel: 'warning',
+                notes: 'Available evenings only.',
+                createdAt: Date.now() - 1000 * 60 * 10,
+            },
+            {
+                id: 'emp-6',
+                name: 'Marcus Allen',
+                role: 'Barback',
+                email: 'marcus.allen@bartending2u.com',
+                phone: '(555) 313-1414',
+                status: 'Available',
+                statusLevel: 'success',
+                notes: 'Strong with load-in/load-out logistics.',
+                createdAt: Date.now() - 1000 * 60 * 45,
+            },
+        ],
+    };
+
+    function clone(data) {
+        return JSON.parse(JSON.stringify(data));
+    }
+
+    function localStorageAvailable() {
+        try {
+            const storage = global.localStorage;
+            if (!storage) {
+                return false;
+            }
+
+            const testKey = `${STORAGE_KEY}__test`;
+            storage.setItem(testKey, '1');
+            storage.removeItem(testKey);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    const hasLocalStorage = localStorageAvailable();
+    let memoryStore = null;
+    let cache = null;
+
+    function readRaw() {
+        if (cache) {
+            return cache;
+        }
+
+        if (hasLocalStorage) {
+            try {
+                const raw = global.localStorage.getItem(STORAGE_KEY);
+                if (!raw) {
+                    cache = clone(defaultData);
+                    return cache;
+                }
+
+                const parsed = JSON.parse(raw);
+                cache = normalise(parsed);
+                return cache;
+            } catch (error) {
+                console.warn('Unable to read scheduler data from localStorage. Using in-memory fallback.', error);
+            }
+        }
+
+        if (!memoryStore) {
+            memoryStore = clone(defaultData);
+        }
+
+        cache = clone(memoryStore);
+        return cache;
+    }
+
+    function writeRaw(data) {
+        const payload = normalise(data);
+        cache = clone(payload);
+
+        if (hasLocalStorage) {
+            try {
+                global.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+                return;
+            } catch (error) {
+                console.warn('Unable to save scheduler data to localStorage. Persisting in memory only.', error);
+            }
+        }
+
+        memoryStore = clone(payload);
+    }
+
+    function normalise(data) {
+        if (!data || typeof data !== 'object') {
+            return clone(defaultData);
+        }
+
+        const normalised = {
+            events: Array.isArray(data.events) ? data.events : [],
+            employees: Array.isArray(data.employees) ? data.employees : [],
+        };
+
+        if (normalised.events.length === 0 && normalised.employees.length === 0) {
+            return clone(defaultData);
+        }
+
+        return normalised;
+    }
+
+    function generateId(prefix) {
+        const randomPart = Math.random().toString(36).slice(2, 8);
+        const timePart = Date.now().toString(36);
+        return `${prefix}-${randomPart}-${timePart}`;
+    }
+
+    function mapStatusLevel(value) {
+        if (!value) {
+            return 'neutral';
+        }
+
+        const lower = value.toLowerCase();
+        if (lower.includes('confirm') || lower.includes('ready') || lower.includes('available') || lower.includes('staffed')) {
+            return 'success';
+        }
+
+        if (lower.includes('need') || lower.includes('limited') || lower.includes('await') || lower.includes('pto')) {
+            return 'warning';
+        }
+
+        if (lower.includes('overdue') || lower.includes('unassign') || lower.includes('contract')) {
+            return 'danger';
+        }
+
+        return 'info';
+    }
+
+    const store = {
+        getSnapshot() {
+            return clone(readRaw());
+        },
+        getEvents() {
+            return clone(readRaw().events);
+        },
+        getEmployees() {
+            return clone(readRaw().employees);
+        },
+        saveSnapshot(next) {
+            writeRaw(next);
+        },
+        addEvent(eventInput) {
+            const snapshot = readRaw();
+            const event = Object.assign(
+                {
+                    id: generateId('evt'),
+                    createdAt: Date.now(),
+                },
+                eventInput
+            );
+
+            if (!event.statusLevel) {
+                event.statusLevel = mapStatusLevel(event.status);
+            }
+            if (!event.staffingLevel) {
+                event.staffingLevel = mapStatusLevel(event.staffingStatus);
+            }
+
+            snapshot.events.push(event);
+            writeRaw(snapshot);
+            return event;
+        },
+        removeEvent(eventId) {
+            const snapshot = readRaw();
+            const nextEvents = snapshot.events.filter((event) => event.id !== eventId);
+            snapshot.events = nextEvents;
+            writeRaw(snapshot);
+        },
+        addEmployee(employeeInput) {
+            const snapshot = readRaw();
+            const employee = Object.assign(
+                {
+                    id: generateId('emp'),
+                    createdAt: Date.now(),
+                },
+                employeeInput
+            );
+
+            if (!employee.statusLevel) {
+                employee.statusLevel = mapStatusLevel(employee.status);
+            }
+
+            snapshot.employees.push(employee);
+            writeRaw(snapshot);
+            return employee;
+        },
+        removeEmployee(employeeId) {
+            const snapshot = readRaw();
+            const nextEmployees = snapshot.employees.filter((employee) => employee.id !== employeeId);
+            snapshot.employees = nextEmployees;
+            writeRaw(snapshot);
+        },
+        clearAll() {
+            writeRaw(clone(defaultData));
+        },
+    };
+
+    global.B2UStore = store;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/styles.css
+++ b/styles.css
@@ -657,6 +657,48 @@ textarea {
   font-weight: 600;
 }
 
+.calendar-cell--empty {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.calendar-cell--today {
+  border: 2px solid rgba(37, 99, 235, 0.25);
+}
+
+.calendar-cell--today .calendar-cell__date {
+  color: var(--primary-600);
+}
+
+.empty-state {
+  padding: 1.25rem;
+  text-align: center;
+  color: var(--slate-500);
+  font-size: 0.95rem;
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: 12px;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--primary-600);
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+
+.link-button:hover,
+.link-button:focus {
+  text-decoration: underline;
+}
+
+.person-card__actions {
+  margin-top: 0.75rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 @media (max-width: 960px) {
   .nav-links {
     position: fixed;


### PR DESCRIPTION
## Summary
- add a standalone storage.js service that seeds defaults, handles localStorage fallback, and exposes CRUD helpers
- rewrite dashboard, events, employees, and calendar pages to render from the shared store and capture new data
- refresh shared styling for empty states, inline buttons, and calendar highlights after removing the old scripts bundle

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68de157cbcd08333b4be40375ce8844a