### PR TITLE
Fix add team member form markup

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -267,8 +267,6 @@
                     </div>
                 </div>
                 <form id="addEmployeeForm">
-                <form id="teamForm">
-                <form>
                     <p class="form-helper-text">Team members are added to your roster immediately. Check the box below if you'd like to send them a portal invite so they can review shifts, pay, and resources.</p>
                     <div class="form-grid">
                         <div class="form-field">
@@ -277,7 +275,6 @@
                         </div>
                         <div class="form-field">
                             <label for="teamRole">Role</label>
-                            <select id="teamRole">
                             <select id="teamRole" name="role" required>
                                 <option value="" selected disabled>Select role</option>
                                 <option>Bartender</option>


### PR DESCRIPTION
## Summary
- remove duplicate form wrappers that were creating invalid markup in the Add team member section
- keep a single role dropdown element so the role can be selected normally when adding a teammate

## Testing
- not run (markup change)


------
https://chatgpt.com/codex/tasks/task_e_68dedba22e6483338e210622b931cea5