### PR TITLE
Add staffing assignment drawer to action needed card

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,19 @@
                 <span class="stat-card__value" id="nextEventName" style="font-size:1.6rem;">No events scheduled</span>
                 <span class="stat-card__meta" id="nextEventMeta">Add an event to build your schedule.</span>
             </article>
-            <article class="stat-card">
+            <article class="stat-card stat-card--interactive">
                 <span class="stat-card__label">Action needed</span>
-                <span class="stat-card__value" id="actionNeededStat" style="color: var(--danger-500);">0</span>
-                <span class="stat-card__meta danger">Unassigned shifts</span>
+                <button
+                    type="button"
+                    class="stat-card__action"
+                    id="actionNeededTrigger"
+                    data-action-needed-trigger
+                    aria-haspopup="dialog"
+                    aria-controls="actionNeededDrawer"
+                >
+                    <span class="stat-card__value" id="actionNeededStat">0</span>
+                    <span class="stat-card__meta danger" id="actionNeededMeta">Unassigned shifts</span>
+                </button>
             </article>
         </section>
 
@@ -240,6 +249,32 @@
                 </table>
             </div>
         </section>
+        <div class="action-needed-overlay" id="actionNeededOverlay" hidden></div>
+        <aside
+            class="action-needed-drawer"
+            id="actionNeededDrawer"
+            role="dialog"
+            aria-modal="true"
+            aria-hidden="true"
+            aria-labelledby="actionNeededTitle"
+        >
+            <div class="action-needed-drawer__header">
+                <h2 class="action-needed-drawer__title" id="actionNeededTitle">Shifts needing staffing</h2>
+                <button type="button" class="icon-button" data-action-needed-close aria-label="Close action needed panel">
+                    ✕
+                </button>
+            </div>
+            <div class="action-needed-drawer__body">
+                <p class="action-needed-drawer__intro">
+                    Review events that still need staffing coverage and quickly assign available team members.
+                </p>
+                <div id="actionNeededFeedback" class="action-needed-drawer__feedback" role="status" aria-live="polite"></div>
+                <div id="actionNeededEmpty" class="action-needed-empty-state" hidden>
+                    All events are fully staffed. Great job!
+                </div>
+                <div id="actionNeededList" class="action-needed-list"></div>
+            </div>
+        </aside>
     </main>
 
     <footer class="app-footer">© 2025 Bartending2U. Crafted for seamless event coordination.</footer>
@@ -507,6 +542,7 @@
             const nextEventName = document.getElementById('nextEventName');
             const nextEventMeta = document.getElementById('nextEventMeta');
             const actionNeeded = document.getElementById('actionNeededStat');
+            const actionNeededMeta = document.getElementById('actionNeededMeta');
 
             if (totalEvents) {
                 totalEvents.textContent = events.length;
@@ -520,6 +556,18 @@
             if (actionNeeded) {
                 const needsStaff = events.filter((event) => event.staffingLevel !== 'success').length;
                 actionNeeded.textContent = needsStaff;
+
+                if (actionNeededMeta) {
+                    actionNeededMeta.textContent =
+                        needsStaff === 0
+                            ? 'All staffed'
+                            : needsStaff === 1
+                            ? 'Shift needs staffing'
+                            : 'Unassigned shifts';
+
+                    actionNeededMeta.classList.toggle('danger', needsStaff > 0);
+                    actionNeededMeta.classList.toggle('success', needsStaff === 0);
+                }
             }
 
             if (nextEventName && nextEventMeta) {
@@ -544,17 +592,266 @@
             }
         }
 
+        function renderActionNeededDrawer(events, employees) {
+            const list = document.getElementById('actionNeededList');
+            const emptyState = document.getElementById('actionNeededEmpty');
+
+            if (!list || !emptyState) {
+                return;
+            }
+
+            list.innerHTML = '';
+
+            const needsStaff = events.filter((event) => event.staffingLevel !== 'success');
+            const availableEmployees = employees.filter((employee) => employee.statusLevel === 'success');
+
+            if (needsStaff.length === 0) {
+                emptyState.hidden = false;
+                return;
+            }
+
+            emptyState.hidden = true;
+
+            needsStaff
+                .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                .forEach((event) => {
+                    const card = document.createElement('section');
+                    card.className = 'action-needed-item';
+
+                    const header = document.createElement('header');
+                    header.className = 'action-needed-item__header';
+
+                    const title = document.createElement('h3');
+                    title.className = 'action-needed-item__title';
+                    title.textContent = event.name;
+
+                    const date = document.createElement('p');
+                    date.className = 'action-needed-item__date';
+                    date.textContent = formatDateTime(event.date, event.time);
+
+                    header.appendChild(title);
+                    header.appendChild(date);
+                    card.appendChild(header);
+
+                    const status = document.createElement('p');
+                    status.className = 'action-needed-item__status';
+                    status.textContent = event.staffingStatus || 'Staffing pending';
+                    card.appendChild(status);
+
+                    const assignedNames = Array.isArray(event.assignedTeam)
+                        ? event.assignedTeam
+                              .map((id) => {
+                                  const match = employees.find((employee) => employee.id === id);
+                                  return match ? match.name : null;
+                              })
+                              .filter(Boolean)
+                        : [];
+
+                    if (assignedNames.length > 0) {
+                        const assigned = document.createElement('p');
+                        assigned.className = 'action-needed-item__assigned';
+                        assigned.textContent = `Currently assigned: ${assignedNames.join(', ')}`;
+                        card.appendChild(assigned);
+                    }
+
+                    const form = document.createElement('form');
+                    form.className = 'action-needed-form';
+                    form.dataset.eventId = event.id;
+
+                    const description = document.createElement('p');
+                    description.className = 'action-needed-form__help';
+                    description.textContent = 'Assign available team members to cover this event.';
+                    form.appendChild(description);
+
+                    if (availableEmployees.length === 0) {
+                        const noTeam = document.createElement('p');
+                        noTeam.className = 'action-needed-form__empty';
+                        noTeam.textContent = 'No team members are currently available. Update availability in the Employees tab.';
+                        form.appendChild(noTeam);
+                    } else {
+                        const checklist = document.createElement('div');
+                        checklist.className = 'action-needed-form__checklist';
+
+                        availableEmployees.forEach((employee) => {
+                            const wrapper = document.createElement('label');
+                            wrapper.className = 'action-needed-form__option';
+
+                            const input = document.createElement('input');
+                            input.type = 'checkbox';
+                            input.name = `assignment-${event.id}`;
+                            input.value = employee.id;
+                            input.checked = Array.isArray(event.assignedTeam) && event.assignedTeam.includes(employee.id);
+
+                            const span = document.createElement('span');
+                            span.innerHTML = `<strong>${employee.name}</strong><small>${employee.role}</small>`;
+
+                            wrapper.appendChild(input);
+                            wrapper.appendChild(span);
+                            checklist.appendChild(wrapper);
+                        });
+
+                        form.appendChild(checklist);
+                    }
+
+                    const actions = document.createElement('div');
+                    actions.className = 'action-needed-form__actions';
+
+                    const submit = document.createElement('button');
+                    submit.type = 'submit';
+                    submit.className = 'button primary';
+                    submit.textContent = 'Assign selected team';
+                    submit.disabled = availableEmployees.length === 0;
+
+                    actions.appendChild(submit);
+                    form.appendChild(actions);
+                    card.appendChild(form);
+                    list.appendChild(card);
+
+                });
+        }
+
+        function attachActionNeededHandlers(state) {
+            const trigger = document.querySelector('[data-action-needed-trigger]');
+            const drawer = document.getElementById('actionNeededDrawer');
+            const overlay = document.getElementById('actionNeededOverlay');
+            const closeButton = document.querySelector('[data-action-needed-close]');
+            const feedback = document.getElementById('actionNeededFeedback');
+
+            if (!trigger || !drawer) {
+                return;
+            }
+
+            const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+            let lastFocusedElement = null;
+
+            const setOpenState = (isOpen) => {
+                drawer.classList.toggle('open', isOpen);
+                drawer.setAttribute('aria-hidden', String(!isOpen));
+
+                if (overlay) {
+                    overlay.hidden = !isOpen;
+                    overlay.classList.toggle('open', isOpen);
+                }
+
+                document.body.classList.toggle('drawer-open', isOpen);
+
+                if (isOpen) {
+                    const focusable = drawer.querySelectorAll(focusableSelectors);
+                    if (focusable.length > 0) {
+                        focusable[0].focus();
+                    }
+                } else if (lastFocusedElement) {
+                    lastFocusedElement.focus();
+                    lastFocusedElement = null;
+                }
+            };
+
+            const openDrawer = () => {
+                lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+                if (feedback) {
+                    feedback.textContent = '';
+                }
+                renderActionNeededDrawer(state.events, state.employees);
+                setOpenState(true);
+            };
+
+            const closeDrawer = () => {
+                setOpenState(false);
+            };
+
+            trigger.addEventListener('click', () => {
+                if (trigger.disabled) {
+                    return;
+                }
+                openDrawer();
+            });
+
+            if (overlay) {
+                overlay.addEventListener('click', closeDrawer);
+            }
+
+            if (closeButton) {
+                closeButton.addEventListener('click', closeDrawer);
+            }
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && drawer.classList.contains('open')) {
+                    closeDrawer();
+                }
+            });
+
+            document.addEventListener('submit', (event) => {
+                const form = event.target;
+                if (!(form instanceof HTMLFormElement)) {
+                    return;
+                }
+
+                if (!form.classList.contains('action-needed-form')) {
+                    return;
+                }
+
+                event.preventDefault();
+                const eventId = form.dataset.eventId;
+                if (!eventId) {
+                    return;
+                }
+
+                const checked = Array.from(form.querySelectorAll('input[type="checkbox"]:checked'));
+                const selectedIds = checked.map((input) => input.value);
+
+                const assignedNames = state.employees
+                    .filter((employee) => selectedIds.includes(employee.id))
+                    .map((employee) => employee.name);
+
+                const staffingStatus = assignedNames.length
+                    ? `Assigned team: ${assignedNames.join(', ')}`
+                    : 'Staffing pending';
+                const staffingLevel = assignedNames.length ? 'success' : 'warning';
+
+                store.updateEvent(eventId, {
+                    assignedTeam: selectedIds,
+                    staffingStatus,
+                    staffingLevel,
+                });
+
+                state.events = store.getEvents();
+                state.employees = store.getEmployees();
+
+                renderActivity(state.events, state.employees);
+                renderDashboardEvents(
+                    state.events
+                        .slice()
+                        .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
+                );
+                renderStaffingAlerts(state.events);
+                updateStats(state.events, state.employees);
+                renderActionNeededDrawer(state.events, state.employees);
+
+                if (feedback) {
+                    const updatedEvent = state.events.find((item) => item.id === eventId);
+                    feedback.textContent = assignedNames.length
+                        ? `${updatedEvent ? updatedEvent.name : 'Event'} now has ${assignedNames.length} team member${assignedNames.length === 1 ? '' : 's'} assigned.`
+                        : 'Assignment removed. This event still needs staffing.';
+                }
+            });
+        }
+
         if (store) {
-            const events = store.getEvents();
-            const employees = store.getEmployees();
-            renderActivity(events, employees);
+            const state = {
+                events: store.getEvents(),
+                employees: store.getEmployees(),
+            };
+
+            renderActivity(state.events, state.employees);
             renderDashboardEvents(
-                events
+                state.events
                     .slice()
                     .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
             );
-            renderStaffingAlerts(events);
-            updateStats(events, employees);
+            renderStaffingAlerts(state.events);
+            updateStats(state.events, state.employees);
+            renderActionNeededDrawer(state.events, state.employees);
+            attachActionNeededHandlers(state);
         }
     </script>
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,10 @@ body.nav-open {
   overflow: hidden;
 }
 
+body.drawer-open {
+  overflow: hidden;
+}
+
 body.nav-open::before {
   content: "";
   position: fixed;
@@ -300,6 +304,258 @@ img {
 
 .stat-card__meta.danger {
   color: var(--danger-500);
+}
+
+.stat-card--interactive .stat-card__value {
+  color: var(--danger-500);
+}
+
+.stat-card__action {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.stat-card__action:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 4px;
+  border-radius: 14px;
+  padding: 0.2rem 0.35rem;
+  margin: -0.2rem -0.35rem;
+}
+
+.stat-card__action[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.stat-card__action[disabled] .stat-card__value {
+  color: var(--slate-500);
+}
+
+.action-needed-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 40;
+}
+
+.action-needed-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.action-needed-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  height: 100%;
+  background: var(--surface);
+  box-shadow: -18px 0 40px -25px rgba(15, 23, 42, 0.4);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  z-index: 45;
+}
+
+.action-needed-drawer.open {
+  transform: translateX(0);
+}
+
+.action-needed-drawer__header {
+  padding: 1.5rem 1.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.action-needed-drawer__title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--slate-900);
+}
+
+.icon-button {
+  border: none;
+  background: var(--surface-soft);
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  color: var(--slate-600);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.icon-button:hover {
+  background: var(--primary-50);
+  color: var(--primary-600);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
+}
+
+.action-needed-drawer__body {
+  padding: 1.5rem 1.75rem 2.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.action-needed-drawer__intro {
+  font-size: 0.95rem;
+  color: var(--slate-600);
+}
+
+.action-needed-drawer__feedback {
+  min-height: 1.2rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--primary-600);
+}
+
+.action-needed-empty-state {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--success-500);
+  background: rgba(16, 185, 129, 0.12);
+  padding: 1.1rem 1rem;
+  border-radius: 14px;
+  text-align: center;
+}
+
+.action-needed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.action-needed-item {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  background: var(--surface-soft);
+}
+
+.action-needed-item__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.action-needed-item__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--slate-900);
+}
+
+.action-needed-item__date {
+  font-size: 0.9rem;
+  color: var(--slate-500);
+}
+
+.action-needed-item__status {
+  font-size: 0.95rem;
+  color: var(--danger-500);
+  font-weight: 600;
+}
+
+.action-needed-item__assigned {
+  font-size: 0.85rem;
+  color: var(--slate-600);
+}
+
+.action-needed-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.action-needed-form__help {
+  font-size: 0.9rem;
+  color: var(--slate-600);
+}
+
+.action-needed-form__empty {
+  font-size: 0.9rem;
+  color: var(--slate-500);
+  background: rgba(100, 116, 139, 0.12);
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+}
+
+.action-needed-form__checklist {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.action-needed-form__option {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: #fff;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.4);
+}
+
+.action-needed-form__option input {
+  margin-top: 0.2rem;
+}
+
+.action-needed-form__option span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.action-needed-form__option span small {
+  font-size: 0.8rem;
+  color: var(--slate-500);
+}
+
+.action-needed-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.action-needed-form__actions .button {
+  min-width: 180px;
+}
+
+@media (max-width: 640px) {
+  .action-needed-drawer {
+    width: 100%;
+  }
+
+  .action-needed-drawer__body {
+    padding-bottom: 4rem;
+  }
 }
 
 .content-card {


### PR DESCRIPTION
## Summary
- turn the dashboard "Action needed" stat into an accessible trigger that opens a staffing drawer
- show a detailed queue of understaffed events with employee checklists and assignment feedback
- persist staffing assignments via the shared store so stats, alerts, and drawer stay in sync

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dedc35e2fc83339295a631845c00f5