### PR TITLE
Add teammate removal controls to employee directory

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -106,7 +106,12 @@
                             <h3 class="details-name" id="detailName">Select a teammate</h3>
                             <p class="details-role" id="detailRole">Profile details will appear here.</p>
                         </div>
-                        <span class="badge" id="detailStatus">—</span>
+                        <div class="details-header__meta">
+                            <span class="badge" id="detailStatus">—</span>
+                            <button class="button danger small" type="button" id="removeEmployeeButton" disabled>
+                                Remove teammate
+                            </button>
+                        </div>
                     </div>
 
                     <div class="details-section">
@@ -419,7 +424,7 @@
             });
         }
 
-        const employees = [
+        let employees = [
             {
                 id: 'john-doe',
                 name: 'John Doe',
@@ -552,6 +557,7 @@
         const detailNotes = document.getElementById('detailNotes');
         const detailDocs = document.getElementById('detailDocs');
         const detailAssignments = document.getElementById('detailAssignments');
+        const removeEmployeeButton = document.getElementById('removeEmployeeButton');
         const characterCount = document.getElementById('characterCount');
         const blastMessage = document.getElementById('blastMessage');
         const blastSubject = document.getElementById('blastSubject');
@@ -611,6 +617,58 @@
             return employees.find((person) => person.id === selectedEmployeeId);
         }
 
+        function clearEmployeeDetails() {
+            if (!detailName || !detailRole || !detailStatus) {
+                return;
+            }
+
+            detailName.textContent = 'Select a teammate';
+            detailRole.textContent = 'Profile details will appear here.';
+            detailStatus.textContent = '—';
+            detailStatus.className = 'badge';
+
+            if (detailEmail) {
+                detailEmail.textContent = 'team@bartending2u.com';
+                detailEmail.href = 'mailto:team@bartending2u.com';
+            }
+
+            if (detailPhone) {
+                detailPhone.textContent = '(555) 123-4567';
+                detailPhone.href = 'tel:+15551234567';
+            }
+
+            if (detailLocation) {
+                detailLocation.textContent = 'Houston Metro';
+            }
+
+            if (detailNotes) {
+                detailNotes.textContent = 'Document specialties, awards, and go-to pairings for your star team members.';
+            }
+
+            if (detailAssignments) {
+                detailAssignments.innerHTML = '';
+                const pill = document.createElement('li');
+                pill.className = 'text-muted';
+                pill.textContent = 'Assignments will populate once you select a teammate.';
+                detailAssignments.appendChild(pill);
+            }
+
+            if (detailDocs) {
+                detailDocs.innerHTML = '';
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 4;
+                cell.className = 'text-muted';
+                cell.textContent = 'Select a teammate to review documentation.';
+                row.appendChild(cell);
+                detailDocs.appendChild(row);
+            }
+
+            if (removeEmployeeButton) {
+                removeEmployeeButton.disabled = true;
+            }
+        }
+
         function isSmsSelected() {
             const checked = document.querySelector('input[name="blastType"]:checked');
             return checked ? checked.value === 'sms' : false;
@@ -638,6 +696,8 @@
                 emptyState.className = 'empty-state';
                 emptyState.textContent = 'No teammates match your filters just yet.';
                 employeeList.appendChild(emptyState);
+                selectedEmployeeId = null;
+                clearEmployeeDetails();
                 return;
             }
 
@@ -683,7 +743,10 @@
             const previousId = selectedEmployeeId;
             selectedEmployeeId = id;
             const employee = getSelectedEmployee();
-            if (!employee || !employeeDetails) return;
+            if (!employee || !employeeDetails) {
+                clearEmployeeDetails();
+                return;
+            }
 
             const cards = employeeList.querySelectorAll('.person-card');
             cards.forEach((card) => {
@@ -767,6 +830,10 @@
                     detailAssignments.appendChild(pill);
                 }
             }
+
+            if (removeEmployeeButton) {
+                removeEmployeeButton.disabled = false;
+            }
         }
 
         function applyFilters() {
@@ -801,6 +868,29 @@
                 applyFilters();
             });
         });
+
+        function removeSelectedEmployee() {
+            const employee = getSelectedEmployee();
+            if (!employee) {
+                return;
+            }
+
+            const confirmed = window.confirm(`Remove ${employee.name} from your roster? This action cannot be undone.`);
+            if (!confirmed) {
+                return;
+            }
+
+            employees = employees.filter((person) => person.id !== employee.id);
+            selectedEmployeeId = null;
+            setAlert(docAlert, '');
+            applyFilters();
+            buildComplianceLists();
+            updateBlastPreview();
+        }
+
+        if (removeEmployeeButton) {
+            removeEmployeeButton.addEventListener('click', removeSelectedEmployee);
+        }
 
         function buildComplianceLists() {
             const tabcExpiring = [];

--- a/styles.css
+++ b/styles.css
@@ -513,6 +513,12 @@ tr:hover td {
   transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
+.button.small {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.8rem;
+  border-radius: 10px;
+}
+
 .button.primary {
   background: var(--primary-600);
   color: #fff;
@@ -531,6 +537,22 @@ tr:hover td {
 
 .button.ghost:hover {
   background: rgba(37, 99, 235, 0.18);
+}
+
+.button.danger {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--danger-500);
+}
+
+.button.danger:hover,
+.button.danger:focus {
+  background: rgba(239, 68, 68, 0.18);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .form-grid {
@@ -821,6 +843,17 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   align-items: flex-start;
+}
+
+.details-header__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.details-header__meta .badge {
+  align-self: flex-end;
 }
 
 .details-name {


### PR DESCRIPTION
## Summary
- add a remove teammate button to the employee profile panel and wire it up to the directory data
- reset the employee detail view when a teammate is removed and refresh roster-driven insights
- style a compact destructive button for the new action in the detail header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedd44f27483338a219a3765a23576