### PR TITLE
Add tax and identification capture to employee profiles

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -129,6 +129,28 @@
                     </div>
 
                     <div class="details-section">
+                        <h4>Tax &amp; identification</h4>
+                        <dl class="details-list">
+                            <div>
+                                <dt>Home address</dt>
+                                <dd id="detailAddress" class="multiline">—</dd>
+                            </div>
+                            <div>
+                                <dt>Tax ID / SSN</dt>
+                                <dd id="detailTaxId">—</dd>
+                            </div>
+                            <div>
+                                <dt>Driver's license</dt>
+                                <dd id="detailLicense">—</dd>
+                            </div>
+                            <div>
+                                <dt>Date of birth</dt>
+                                <dd id="detailDob">—</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="details-section">
                         <h4>Upcoming assignments</h4>
                         <ul class="details-pills" id="detailAssignments">
                             <li class="text-muted">Assignments will populate once you select a teammate.</li>
@@ -306,6 +328,46 @@
                             </select>
                         </div>
                     </div>
+                    <div class="form-grid">
+                        <div class="form-field full-width">
+                            <label for="teamAddressLine1">Home address</label>
+                            <input id="teamAddressLine1" name="addressLine1" type="text" placeholder="Street address" />
+                        </div>
+                        <div class="form-field full-width">
+                            <label for="teamAddressLine2">Apartment, suite, etc. (optional)</label>
+                            <input id="teamAddressLine2" name="addressLine2" type="text" placeholder="Unit or floor" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamCity">City</label>
+                            <input id="teamCity" name="city" type="text" placeholder="City" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamState">State</label>
+                            <input id="teamState" name="state" type="text" maxlength="2" placeholder="TX" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamPostalCode">ZIP code</label>
+                            <input id="teamPostalCode" name="postalCode" type="text" placeholder="75201" />
+                        </div>
+                    </div>
+                    <div class="form-grid">
+                        <div class="form-field">
+                            <label for="teamSsn">Tax ID / SSN</label>
+                            <input id="teamSsn" name="taxId" type="text" placeholder="123-45-6789" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamDob">Date of birth</label>
+                            <input id="teamDob" name="dob" type="date" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamDlNumber">Driver's license number</label>
+                            <input id="teamDlNumber" name="dlNumber" type="text" placeholder="TX1234567" />
+                        </div>
+                        <div class="form-field">
+                            <label for="teamDlState">Issuing state</label>
+                            <input id="teamDlState" name="dlState" type="text" maxlength="2" placeholder="TX" />
+                        </div>
+                    </div>
                     <div class="form-field">
                         <label for="teamNotes">Specialties & certifications</label>
                         <textarea id="teamNotes" name="notes" placeholder="E.g. flair bartending, wine pairing, bilingual"></textarea>
@@ -431,6 +493,15 @@
                 location: 'Houston, TX',
                 email: 'john.doe@bartending2u.com',
                 phone: '(713) 555-0114',
+                addressLine1: '1901 Market St',
+                addressLine2: 'Suite 210',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77002',
+                taxId: '123-45-6789',
+                dob: '1984-07-19',
+                dlNumber: 'TX12345678',
+                dlState: 'TX',
                 notes: 'Lead trainer for new hires. Loves crafting signature welcome cocktails.',
                 assignments: [
                     'Corporate Party — Oct 5 (Lead bartender)',
@@ -451,6 +522,15 @@
                 location: 'Austin, TX',
                 email: 'jane.smith@bartending2u.com',
                 phone: '(512) 555-0199',
+                addressLine1: '501 Congress Ave',
+                addressLine2: 'Apt 9B',
+                addressCity: 'Austin',
+                addressState: 'TX',
+                addressPostalCode: '78701',
+                taxId: '234-56-7890',
+                dob: '1990-02-11',
+                dlNumber: 'TX87654321',
+                dlState: 'TX',
                 notes: 'Certified sommelier. Currently on PTO returning Oct 14.',
                 assignments: [
                     'Mocktail Workshop — Oct 22 (Program design)'
@@ -470,6 +550,15 @@
                 location: 'Dallas, TX',
                 email: 'alex.rivera@bartending2u.com',
                 phone: '(469) 555-0147',
+                addressLine1: '1400 Elm St',
+                addressLine2: '',
+                addressCity: 'Dallas',
+                addressState: 'TX',
+                addressPostalCode: '75202',
+                taxId: '345-67-8901',
+                dob: '1988-11-03',
+                dlNumber: 'TX44556677',
+                dlState: 'TX',
                 notes: 'Lead for sports stadium activations. Fluent in Spanish and English.',
                 assignments: [
                     'Corporate Party — Oct 5 (Support)',
@@ -490,6 +579,15 @@
                 location: 'Houston, TX',
                 email: 'priya.singh@bartending2u.com',
                 phone: '(832) 555-0177',
+                addressLine1: '2220 Westheimer Rd',
+                addressLine2: 'Unit 5',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77098',
+                taxId: '456-78-9012',
+                dob: '1986-05-27',
+                dlNumber: 'TX99887766',
+                dlState: 'TX',
                 notes: 'Hosts quarterly workshops and champions zero-proof menu innovation.',
                 assignments: [
                     'Mixology Workshop — Oct 18 (Instructor)',
@@ -510,6 +608,15 @@
                 location: 'San Antonio, TX',
                 email: 'jamie.lee@bartending2u.com',
                 phone: '(210) 555-0188',
+                addressLine1: '815 Avenue B',
+                addressLine2: '',
+                addressCity: 'San Antonio',
+                addressState: 'TX',
+                addressPostalCode: '78215',
+                taxId: '567-89-0123',
+                dob: '1992-09-14',
+                dlNumber: 'TX11223344',
+                dlState: 'TX',
                 notes: 'Available for load-ins and barback duties Thursdays through Sundays.',
                 assignments: [
                     'Mixology Workshop — Oct 18 (Support)'
@@ -529,6 +636,15 @@
                 location: 'Houston, TX',
                 email: 'marcus.allen@bartending2u.com',
                 phone: '(713) 555-0160',
+                addressLine1: '3710 Main St',
+                addressLine2: '',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77002',
+                taxId: '678-90-1234',
+                dob: '1987-03-08',
+                dlNumber: 'TX55667788',
+                dlState: 'TX',
                 notes: 'Great with tight timelines and closing shifts. CDL certified.',
                 assignments: [
                     'Wedding Reception — Oct 15 (Barback)',
@@ -550,6 +666,10 @@
         const detailEmail = document.getElementById('detailEmail');
         const detailPhone = document.getElementById('detailPhone');
         const detailLocation = document.getElementById('detailLocation');
+        const detailAddress = document.getElementById('detailAddress');
+        const detailTaxId = document.getElementById('detailTaxId');
+        const detailLicense = document.getElementById('detailLicense');
+        const detailDob = document.getElementById('detailDob');
         const detailNotes = document.getElementById('detailNotes');
         const detailDocs = document.getElementById('detailDocs');
         const detailAssignments = document.getElementById('detailAssignments');
@@ -572,6 +692,15 @@
         const teamRoleInput = document.getElementById('teamRole');
         const teamEmailInput = document.getElementById('teamEmail');
         const teamPhoneInput = document.getElementById('teamPhone');
+        const teamAddressLine1Input = document.getElementById('teamAddressLine1');
+        const teamAddressLine2Input = document.getElementById('teamAddressLine2');
+        const teamCityInput = document.getElementById('teamCity');
+        const teamStateInput = document.getElementById('teamState');
+        const teamPostalCodeInput = document.getElementById('teamPostalCode');
+        const teamSsnInput = document.getElementById('teamSsn');
+        const teamDobInput = document.getElementById('teamDob');
+        const teamDlNumberInput = document.getElementById('teamDlNumber');
+        const teamDlStateInput = document.getElementById('teamDlState');
         const teamNotesInput = document.getElementById('teamNotes');
 
         const complianceLists = {
@@ -680,6 +809,52 @@
             selectEmployee(selectedEmployeeId);
         }
 
+        function formatAddress(employee) {
+            if (!employee) return '';
+            const segments = [];
+            const line1 = (employee.addressLine1 || '').trim();
+            const line2 = (employee.addressLine2 || '').trim();
+            const city = (employee.addressCity || '').trim();
+            const state = (employee.addressState || '').trim();
+            const postal = (employee.addressPostalCode || '').trim();
+
+            if (line1) segments.push(line1);
+            if (line2) segments.push(line2);
+
+            const cityState = [city, state].filter(Boolean).join(', ');
+            const finalLine = [cityState, postal].filter(Boolean).join(' ').trim();
+            if (finalLine) segments.push(finalLine);
+
+            return segments.join('\n');
+        }
+
+        function formatDob(value) {
+            if (!value) return '';
+            const parts = value.split('-').map((part) => parseInt(part, 10));
+            if (parts.length === 3 && parts.every((num) => !Number.isNaN(num))) {
+                const [year, month, day] = parts;
+                const parsed = new Date(year, month - 1, day);
+                if (!Number.isNaN(parsed.getTime())) {
+                    return new Intl.DateTimeFormat('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric'
+                    }).format(parsed);
+                }
+            }
+
+            const fallback = new Date(value);
+            if (!Number.isNaN(fallback.getTime())) {
+                return new Intl.DateTimeFormat('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric'
+                }).format(fallback);
+            }
+
+            return value;
+        }
+
         function selectEmployee(id) {
             const previousId = selectedEmployeeId;
             selectedEmployeeId = id;
@@ -705,6 +880,27 @@
             const digits = employee.phone.replace(/[^0-9]/g, '');
             detailPhone.href = digits ? `tel:+1${digits}` : '#';
             detailLocation.textContent = employee.location;
+            const address = formatAddress(employee);
+            if (detailAddress) {
+                detailAddress.textContent = address || '—';
+            }
+            if (detailTaxId) {
+                detailTaxId.textContent = employee.taxId && employee.taxId.trim() ? employee.taxId.trim() : '—';
+            }
+            if (detailLicense) {
+                const licenseParts = [];
+                if (employee.dlNumber && employee.dlNumber.trim()) {
+                    licenseParts.push(employee.dlNumber.trim());
+                }
+                if (employee.dlState && employee.dlState.trim()) {
+                    licenseParts.push(`(${employee.dlState.trim()})`);
+                }
+                detailLicense.textContent = licenseParts.length ? licenseParts.join(' ') : '—';
+            }
+            if (detailDob) {
+                const dob = formatDob(employee.dob);
+                detailDob.textContent = dob || '—';
+            }
             detailNotes.textContent = employee.notes;
 
             detailDocs.innerHTML = '';
@@ -964,12 +1160,23 @@
                 const role = teamRoleInput ? teamRoleInput.value.trim() : '';
                 const email = teamEmailInput ? teamEmailInput.value.trim() : '';
                 const phone = teamPhoneInput ? teamPhoneInput.value.trim() : '';
+                const addressLine1 = teamAddressLine1Input ? teamAddressLine1Input.value.trim() : '';
+                const addressLine2 = teamAddressLine2Input ? teamAddressLine2Input.value.trim() : '';
+                const addressCity = teamCityInput ? teamCityInput.value.trim() : '';
+                const addressState = teamStateInput ? teamStateInput.value.trim() : '';
+                const addressPostalCode = teamPostalCodeInput ? teamPostalCodeInput.value.trim() : '';
+                const taxId = teamSsnInput ? teamSsnInput.value.trim() : '';
+                const dobRaw = teamDobInput ? teamDobInput.value : '';
+                const dlNumber = teamDlNumberInput ? teamDlNumberInput.value.trim() : '';
+                const dlState = teamDlStateInput ? teamDlStateInput.value.trim() : '';
                 const notes = teamNotesInput ? teamNotesInput.value.trim() : '';
 
                 if (!name || !email) {
                     setAlert(addEmployeeAlert, 'Please add a name and email before inviting a teammate.', 'danger');
                     return;
                 }
+
+                const locationLabel = [addressCity, addressState].filter(Boolean).join(', ') || 'TBD';
 
                 const summaryRaw = notes
                     ? notes
@@ -992,9 +1199,18 @@
                     specialties,
                     status: 'available',
                     statusLabel: 'Available',
-                    location: 'TBD',
+                    location: locationLabel,
                     email,
                     phone: phone || '—',
+                    addressLine1,
+                    addressLine2,
+                    addressCity,
+                    addressState,
+                    addressPostalCode,
+                    taxId,
+                    dob: dobRaw,
+                    dlNumber,
+                    dlState,
                     notes: detailNotes,
                     assignments: [],
                     documents: []

--- a/styles.css
+++ b/styles.css
@@ -539,6 +539,10 @@ tr:hover td {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.form-field.full-width {
+  grid-column: 1 / -1;
+}
+
 .form-field {
   display: flex;
   flex-direction: column;
@@ -862,6 +866,10 @@ textarea {
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--slate-700);
+}
+
+.details-list dd.multiline {
+  white-space: pre-line;
 }
 
 .details-pills {


### PR DESCRIPTION
## Summary
- add a tax & identification section to the employee detail panel with address, SSN, license, and DOB fields
- extend the add teammate form and seed data to capture required 1099 contact details
- update styling to support multi-line addresses and full-width form inputs

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dede9ebc2483338dcb0b7e9bff1c1f