### PR TITLE
Add employee portal management tools

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@
     const subsectionElements = Array.from(document.querySelectorAll('[data-subsection]'));
     if (subsectionElements.length > 1) {
         const pageContent = document.querySelector('.page-content');
+        const allowEmptyState = pageContent && pageContent.dataset.subsectionAllowEmpty === 'true';
         const header = pageContent ? pageContent.querySelector('.page-header') : null;
         const sectionToButton = new Map();
 
@@ -89,9 +90,11 @@
             button.textContent = section.dataset.subsection || `Section ${index + 1}`;
             button.setAttribute('aria-controls', section.id);
 
-            if (index === 0) {
+            if (!allowEmptyState && index === 0) {
                 button.classList.add('is-active');
-            } else {
+            }
+
+            if (allowEmptyState || index !== 0) {
                 section.classList.add('is-hidden');
             }
 

--- a/employees.html
+++ b/employees.html
@@ -45,7 +45,7 @@
         </div>
     </header>
 
-    <main class="page-content">
+    <main class="page-content" data-subsection-allow-empty="true">
         <section class="page-header">
             <div>
                 <p class="page-eyebrow">Team</p>
@@ -173,6 +173,44 @@
                             </div>
                         </form>
                         <p class="form-alert" id="docAlert" role="status" aria-live="polite"></p>
+                    </div>
+
+                    <div class="details-section" id="portalAccessSection">
+                        <div class="details-section__header">
+                            <h4>Portal access</h4>
+                            <div class="portal-access__actions">
+                                <button class="button ghost" type="button" id="togglePortalActivity">View login activity</button>
+                                <button class="button primary" type="button" id="resetPortalPassword">Reset password</button>
+                                <button class="button ghost" type="button" id="resendPortalInvite">Resend invite</button>
+                            </div>
+                        </div>
+                        <dl class="details-list">
+                            <div>
+                                <dt>Status</dt>
+                                <dd><span class="badge" id="portalStatusBadge">Invite pending</span></dd>
+                            </div>
+                            <div>
+                                <dt>Last login</dt>
+                                <dd id="portalLastLogin">No logins yet</dd>
+                            </div>
+                            <div>
+                                <dt>Access level</dt>
+                                <dd id="portalAccessLevel">—</dd>
+                            </div>
+                            <div>
+                                <dt>Invite sent</dt>
+                                <dd id="portalInviteSent">—</dd>
+                            </div>
+                            <div>
+                                <dt>Multi-factor auth</dt>
+                                <dd id="portalMfa">Not enabled</dd>
+                            </div>
+                        </dl>
+                        <div class="portal-login-activity is-hidden" id="portalLoginActivity">
+                            <h5 class="portal-login-activity__title">Recent activity</h5>
+                            <ul class="portal-login-list" id="portalLoginList"></ul>
+                        </div>
+                        <p class="form-alert" id="portalAlert" role="status" aria-live="polite"></p>
                     </div>
 
                     <div class="details-section">
@@ -439,7 +477,23 @@
                 documents: [
                     { type: 'TABC Certificate', status: 'Active', expires: '2025-05-12', url: '#', attention: false },
                     { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
-                ]
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Full portal access',
+                    inviteSentAt: '2024-06-20T15:30:00',
+                    lastLogin: '2025-10-01T09:42:00',
+                    mfaEnabled: true,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-10-01T09:42:00', action: 'Logged in on desktop', location: 'Houston, TX' },
+                        { timestamp: '2025-09-28T17:22:00', action: 'Reviewed corporate party schedule', location: 'Houston, TX' },
+                        { timestamp: '2025-09-26T11:08:00', action: 'Downloaded pay stub', location: 'Mobile · Austin, TX' }
+                    ]
+                }
             },
             {
                 id: 'jane-smith',
@@ -458,7 +512,19 @@
                 documents: [
                     { type: 'TABC Certificate', status: 'Expiring soon', expires: '2024-10-30', url: '#', attention: true },
                     { type: 'Food Handler', status: 'Submitted', expires: '2026-02-01', url: '#', attention: false }
-                ]
+                ],
+                portal: {
+                    status: 'invite-pending',
+                    statusLabel: 'Invite pending',
+                    statusLevel: 'warning',
+                    accessLevel: 'Awaiting portal activation',
+                    inviteSentAt: '2025-09-20T13:15:00',
+                    lastLogin: null,
+                    mfaEnabled: false,
+                    canResetPassword: false,
+                    canResendInvite: true,
+                    loginActivity: []
+                }
             },
             {
                 id: 'alex-rivera',
@@ -478,7 +544,22 @@
                 documents: [
                     { type: 'TABC Certificate', status: 'Active', expires: '2026-01-19', url: '#', attention: false },
                     { type: 'Food Handler', status: 'Pending upload', expires: '—', url: '#', attention: true }
-                ]
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Schedule + pay stubs',
+                    inviteSentAt: '2024-08-05T10:05:00',
+                    lastLogin: '2025-09-30T18:10:00',
+                    mfaEnabled: false,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-30T18:10:00', action: 'Logged in on mobile', location: 'Dallas, TX' },
+                        { timestamp: '2025-09-27T08:55:00', action: 'Confirmed shift availability', location: 'Dallas, TX' }
+                    ]
+                }
             },
             {
                 id: 'priya-singh',
@@ -498,7 +579,23 @@
                 documents: [
                     { type: 'TABC Certificate', status: 'Active', expires: '2025-11-08', url: '#', attention: false },
                     { type: 'W-9', status: 'On file', expires: '—', url: '#', attention: false }
-                ]
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Manager access',
+                    inviteSentAt: '2023-12-12T09:00:00',
+                    lastLogin: '2025-09-29T07:30:00',
+                    mfaEnabled: true,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-29T07:30:00', action: 'Approved workshop roster', location: 'Houston, TX' },
+                        { timestamp: '2025-09-25T19:05:00', action: 'Sent message to mixology team', location: 'Houston, TX' },
+                        { timestamp: '2025-09-21T12:18:00', action: 'Updated availability', location: 'Mobile · Austin, TX' }
+                    ]
+                }
             },
             {
                 id: 'jamie-lee',
@@ -517,7 +614,21 @@
                 documents: [
                     { type: 'TABC Certificate', status: 'Needs renewal', expires: '2024-09-25', url: '#', attention: true },
                     { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
-                ]
+                ],
+                portal: {
+                    status: 'disabled',
+                    statusLabel: 'Access disabled',
+                    statusLevel: 'danger',
+                    accessLevel: 'Portal locked until renewal',
+                    inviteSentAt: '2024-02-10T16:45:00',
+                    lastLogin: '2024-08-18T14:05:00',
+                    mfaEnabled: false,
+                    canResetPassword: false,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2024-08-18T14:05:00', action: 'Account locked after credential expiration', location: 'San Antonio, TX' }
+                    ]
+                }
             },
             {
                 id: 'marcus-allen',
@@ -536,7 +647,22 @@
                 ],
                 documents: [
                     { type: 'Food Handler', status: 'Active', expires: '2025-03-15', url: '#', attention: false }
-                ]
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Schedule access only',
+                    inviteSentAt: '2025-01-12T08:30:00',
+                    lastLogin: '2025-09-24T06:55:00',
+                    mfaEnabled: false,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-24T06:55:00', action: 'Checked load-in checklist', location: 'Houston, TX' },
+                        { timestamp: '2025-09-18T20:40:00', action: 'Confirmed transportation availability', location: 'Mobile · Houston, TX' }
+                    ]
+                }
             }
         ];
 
@@ -553,6 +679,17 @@
         const detailNotes = document.getElementById('detailNotes');
         const detailDocs = document.getElementById('detailDocs');
         const detailAssignments = document.getElementById('detailAssignments');
+        const portalStatusBadge = document.getElementById('portalStatusBadge');
+        const portalLastLogin = document.getElementById('portalLastLogin');
+        const portalAccessLevel = document.getElementById('portalAccessLevel');
+        const portalInviteSent = document.getElementById('portalInviteSent');
+        const portalMfa = document.getElementById('portalMfa');
+        const portalLoginActivity = document.getElementById('portalLoginActivity');
+        const portalLoginList = document.getElementById('portalLoginList');
+        const portalAlert = document.getElementById('portalAlert');
+        const togglePortalActivity = document.getElementById('togglePortalActivity');
+        const resetPortalPassword = document.getElementById('resetPortalPassword');
+        const resendPortalInvite = document.getElementById('resendPortalInvite');
         const characterCount = document.getElementById('characterCount');
         const blastMessage = document.getElementById('blastMessage');
         const blastSubject = document.getElementById('blastSubject');
@@ -586,9 +723,17 @@
             limited: 'badge warning'
         };
 
+        const portalStatusClasses = {
+            active: 'badge success',
+            'invite-pending': 'badge warning',
+            disabled: 'badge danger',
+            locked: 'badge danger'
+        };
+
         const SMS_LIMIT = 160;
 
         let selectedEmployeeId = null;
+        let portalActivityExpanded = false;
 
         function setAlert(element, message, tone = 'info') {
             if (!element) return;
@@ -617,6 +762,25 @@
             return checked ? checked.value === 'sms' : false;
         }
 
+        function formatDateTime(value, { includeTime = true } = {}) {
+            if (!value) {
+                return '';
+            }
+
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+
+            return new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                hour: includeTime ? 'numeric' : undefined,
+                minute: includeTime ? '2-digit' : undefined
+            }).format(date);
+        }
+
         function generateEmployeeId(name) {
             const base = name
                 .toLowerCase()
@@ -624,6 +788,99 @@
                 .replace(/^-+|-+$/g, '');
             const suffix = Date.now().toString(36);
             return `${base || 'teammate'}-${suffix}`;
+        }
+
+        function updatePortalActivityVisibility(hasActivity) {
+            if (!portalLoginActivity || !togglePortalActivity) {
+                return;
+            }
+
+            if (!hasActivity) {
+                portalLoginActivity.classList.remove('is-hidden');
+                togglePortalActivity.textContent = 'No login activity';
+                togglePortalActivity.disabled = true;
+                return;
+            }
+
+            togglePortalActivity.disabled = false;
+            togglePortalActivity.textContent = portalActivityExpanded ? 'Hide login activity' : 'View login activity';
+            portalLoginActivity.classList.toggle('is-hidden', !portalActivityExpanded);
+        }
+
+        function updatePortalAccess(employee) {
+            if (
+                !employee ||
+                !portalStatusBadge ||
+                !portalLastLogin ||
+                !portalAccessLevel ||
+                !portalInviteSent ||
+                !portalMfa ||
+                !portalLoginList
+            ) {
+                return;
+            }
+
+            const portal = employee.portal || {};
+            const badgeClass = portalStatusClasses[portal.status] || 'badge';
+            portalStatusBadge.className = badgeClass;
+            portalStatusBadge.textContent = portal.statusLabel || 'Not invited';
+
+            const lastLoginText = formatDateTime(portal.lastLogin) || 'No logins yet';
+            portalLastLogin.textContent = portal.lastLogin ? lastLoginText : 'No logins yet';
+            portalAccessLevel.textContent = portal.accessLevel || '—';
+            portalInviteSent.textContent = formatDateTime(portal.inviteSentAt) || 'Not sent';
+            portalMfa.textContent = portal.mfaEnabled ? 'Enabled' : 'Not enabled';
+
+            portalLoginList.innerHTML = '';
+            const hasActivity = Array.isArray(portal.loginActivity) && portal.loginActivity.length > 0;
+
+            if (hasActivity) {
+                portal.loginActivity.slice(0, 6).forEach((activity) => {
+                    const item = document.createElement('li');
+                    item.className = 'portal-login-item';
+
+                    const meta = document.createElement('span');
+                    meta.className = 'portal-login-item__meta';
+                    meta.textContent = formatDateTime(activity.timestamp) || 'Timestamp unavailable';
+
+                    const details = document.createElement('span');
+                    details.className = 'portal-login-item__details';
+                    const detailBits = [activity.action, activity.location].filter(Boolean);
+                    details.textContent = detailBits.join(' • ') || 'Portal activity recorded';
+
+                    item.appendChild(meta);
+                    item.appendChild(details);
+                    portalLoginList.appendChild(item);
+                });
+            } else {
+                const item = document.createElement('li');
+                item.className = 'portal-login-item';
+                const details = document.createElement('span');
+                details.className = 'portal-login-item__details';
+                details.textContent = 'No login activity recorded yet.';
+                item.appendChild(details);
+                portalLoginList.appendChild(item);
+            }
+
+            portalActivityExpanded = false;
+            updatePortalActivityVisibility(hasActivity);
+
+            if (portalAlert) {
+                setAlert(portalAlert, '');
+            }
+
+            if (resetPortalPassword) {
+                resetPortalPassword.disabled = !portal.canResetPassword;
+                resetPortalPassword.classList.remove('is-hidden');
+                resetPortalPassword.textContent = portal.resetLabel || 'Reset password';
+            }
+
+            if (resendPortalInvite) {
+                const showResend = Boolean(portal.canResendInvite);
+                resendPortalInvite.classList.toggle('is-hidden', !showResend);
+                resendPortalInvite.disabled = !showResend;
+                resendPortalInvite.textContent = portal.inviteAction || 'Resend invite';
+            }
         }
 
         let activeFilter = 'all';
@@ -706,6 +963,8 @@
             detailPhone.href = digits ? `tel:+1${digits}` : '#';
             detailLocation.textContent = employee.location;
             detailNotes.textContent = employee.notes;
+
+            updatePortalAccess(employee);
 
             detailDocs.innerHTML = '';
             if (employee.documents && employee.documents.length) {
@@ -908,6 +1167,61 @@
                 updateBlastTypeVisibility();
             });
         });
+
+        if (togglePortalActivity) {
+            togglePortalActivity.addEventListener('click', () => {
+                const employee = getSelectedEmployee();
+                const portal = employee ? employee.portal : null;
+                if (!portal || !Array.isArray(portal.loginActivity) || portal.loginActivity.length === 0) {
+                    return;
+                }
+
+                portalActivityExpanded = !portalActivityExpanded;
+                updatePortalActivityVisibility(true);
+            });
+        }
+
+        if (resetPortalPassword) {
+            resetPortalPassword.addEventListener('click', () => {
+                const employee = getSelectedEmployee();
+                if (!employee) {
+                    return;
+                }
+
+                const portal = employee.portal;
+                if (!portal || !portal.canResetPassword) {
+                    setAlert(portalAlert, 'Portal password reset is unavailable for this teammate.', 'danger');
+                    return;
+                }
+
+                const recipient = employee.email || employee.name || 'this teammate';
+                setAlert(portalAlert, `Password reset instructions were emailed to ${recipient}.`, 'success');
+            });
+        }
+
+        if (resendPortalInvite) {
+            resendPortalInvite.addEventListener('click', () => {
+                const employee = getSelectedEmployee();
+                if (!employee) {
+                    return;
+                }
+
+                const portal = employee.portal;
+                if (!portal || !portal.canResendInvite) {
+                    setAlert(portalAlert, 'Portal invite cannot be resent right now.', 'danger');
+                    return;
+                }
+
+                portal.canResendInvite = false;
+                portal.status = portal.status || 'invite-pending';
+                portal.statusLabel = portal.statusLabel || 'Invite pending';
+                portal.inviteSentAt = new Date().toISOString();
+                updatePortalAccess(employee);
+
+                const recipient = employee.email || employee.name || 'this teammate';
+                setAlert(portalAlert, `Portal invite has been re-sent to ${recipient}.`, 'success');
+            });
+        }
 
         if (docForm) {
             docForm.addEventListener('submit', (event) => {

--- a/styles.css
+++ b/styles.css
@@ -845,6 +845,64 @@ textarea {
   color: var(--slate-700);
 }
 
+.details-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.portal-access__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.portal-login-activity {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  background: var(--surface-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-login-activity__title {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--slate-500);
+}
+
+.portal-login-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-login-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.portal-login-item__meta {
+  font-weight: 600;
+  color: var(--slate-700);
+}
+
+.portal-login-item__details {
+  color: var(--slate-500);
+  font-size: 0.9rem;
+}
+
 .details-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));


### PR DESCRIPTION
## Summary
- hide employee page subsections until a navigation button is selected
- surface portal access details including status, MFA, and recent login activity in the employee profile
- add reset password and invite resend interactions with supporting styles for the portal activity log

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68dede347818833396b8b62e0538741c