### PR TITLE
Fix team directory card overflow

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -184,11 +184,16 @@
                         <h4>Notes & strengths</h4>
                         <p class="details-notes" id="detailNotes">Document specialties, awards, and go-to pairings for your star team members.</p>
                     </div>
-            <div class="list-grid" id="teamList"></div>
-            <div class="list-grid">
+                </article>
+            </div>
+
+            <div class="team-grid" id="teamList">
                 <article class="person-card">
                     <h3 class="person-card__name">John Garcia</h3>
                     <p class="person-card__role">Bar Lead · Flair certified</p>
+                    <div class="person-card__status"><span class="badge success">Available</span></div>
+                </article>
+                <article class="person-card">
                     <h3 class="person-card__name">John Doe</h3>
                     <p class="person-card__role">Bartender · Lead flair specialist</p>
                     <div class="person-card__status"><span class="badge success">Available</span></div>

--- a/styles.css
+++ b/styles.css
@@ -914,6 +914,23 @@ textarea {
 }
 
 .directory-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 300px) 1fr;
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.team-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.team-grid:empty {
+  margin-top: 0;
+}
+
 .subsection-nav {
   display: flex;
   flex-wrap: wrap;
@@ -1035,10 +1052,10 @@ textarea {
   border-radius: 16px;
   padding: 1rem 1.1rem;
   border: 1px solid rgba(226, 232, 240, 0.9);
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem 0.85rem;
+  align-items: start;
   text-align: left;
   cursor: pointer;
   transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
@@ -1046,6 +1063,11 @@ textarea {
   font: inherit;
   color: inherit;
   appearance: none;
+  min-width: 0;
+}
+
+.person-card > * {
+  min-width: 0;
 }
 
 .person-card:hover {
@@ -1069,18 +1091,27 @@ textarea {
 .person-card__name {
   font-size: 1.05rem;
   font-weight: 600;
+  grid-column: 1;
 }
 
 .person-card__role {
   font-size: 0.9rem;
   color: var(--slate-500);
-  max-width: 220px;
+  grid-column: 1 / -1;
 }
 
 .person-card__status {
-  margin-left: auto;
+  grid-column: 2;
+  grid-row: 1;
   white-space: nowrap;
-  align-self: center;
+  align-self: start;
+  justify-self: end;
+  margin-left: 0;
+}
+
+.person-card .card-subtitle {
+  grid-column: 1 / -1;
+  color: var(--slate-500);
 }
 
 .directory-details {
@@ -1092,6 +1123,7 @@ textarea {
   flex-direction: column;
   gap: 1.5rem;
   box-shadow: var(--shadow-sm);
+  min-width: 0;
 }
 
 .details-header {
@@ -1407,6 +1439,7 @@ textarea {
 }
 
 .person-card__actions {
+  grid-column: 1 / -1;
   margin-top: 0.75rem;
   display: flex;
   justify-content: flex-end;
@@ -1523,7 +1556,7 @@ textarea {
 
   .card-grid,
   .split-layout,
-  .list-grid {
+  .team-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- close the directory details markup and wrap the roster in a dedicated grid container
- switch person cards to a CSS grid layout so long notes and contacts no longer overflow
- tune team directory spacing and responsiveness for the new grid, including mobile adjustments

## Testing
- Visual inspection of employees directory (see attached screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68dedfc525d4833385b0a346a04c1a77