### PR TITLE
Add document viewer and TABC metadata for employee docs

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -141,13 +141,33 @@
                                 <tr>
                                     <th scope="col">Document</th>
                                     <th scope="col">Status</th>
+                                    <th scope="col">Issued</th>
                                     <th scope="col">Expires</th>
+                                    <th scope="col">License / ID</th>
                                     <th scope="col">File</th>
                                 </tr>
                             </thead>
                             <tbody id="detailDocs"></tbody>
                         </table>
                         <p class="helper-text" id="documentation-helper">Track TABC certificates, liability waivers, and other compliance paperwork.</p>
+                        <div class="modal" id="docViewer" aria-hidden="true">
+                            <div class="modal__overlay" data-modal-close></div>
+                            <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="docViewerTitle" tabindex="-1">
+                                <button class="modal__close link-button" type="button" data-modal-close>Close ×</button>
+                                <div class="modal__header">
+                                    <h5 class="modal__title" id="docViewerTitle">Document preview</h5>
+                                    <p class="modal__subtitle text-muted" id="docViewerSubtitle"></p>
+                                </div>
+                                <dl class="modal__details" id="docViewerMeta"></dl>
+                                <div class="modal__preview">
+                                    <iframe id="docViewerFrame" title="Document preview" sandbox></iframe>
+                                    <p class="modal__placeholder text-muted" id="docViewerPlaceholder">Preview unavailable. Use the download button below to open the file in a new tab.</p>
+                                </div>
+                                <div class="modal__actions">
+                                    <a class="button primary" id="docViewerDownload" target="_blank" rel="noopener">Open in new tab</a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="details-section">
@@ -162,6 +182,21 @@
                                     <option>Food Handler</option>
                                 </select>
                             </label>
+                            <div class="form-grid form-grid--compact" id="tabcMetadata" hidden>
+                                <label class="form-field">
+                                    <span>License / Permit ID</span>
+                                    <input type="text" id="tabcLicense" placeholder="e.g. TX-123456" autocomplete="off" />
+                                </label>
+                                <label class="form-field">
+                                    <span>Issued date</span>
+                                    <input type="date" id="tabcIssued" />
+                                </label>
+                                <label class="form-field">
+                                    <span>Expiration date</span>
+                                    <input type="date" id="tabcExpires" />
+                                </label>
+                            </div>
+                            <p class="helper-text" id="tabcMetadataHelper" hidden>TABC uploads need license ID, issuance, and expiration dates.</p>
                             <label class="form-field">
                                 <span>Attach file</span>
                                 <input type="file" id="docFile" />
@@ -419,6 +454,69 @@
             });
         }
 
+        function formatDisplayDate(value) {
+            if (!value) {
+                return '';
+            }
+
+            const iso = value.length === 10 ? `${value}T00:00:00` : value;
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+
+            return new Intl.DateTimeFormat(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric'
+            }).format(date);
+        }
+
+        function formatDisplayDateTime(value) {
+            if (!value) {
+                return '';
+            }
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return '';
+            }
+
+            return new Intl.DateTimeFormat(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit'
+            }).format(date);
+        }
+
+        function prepareDocument(doc) {
+            const prepared = { ...doc };
+            if (prepared.expires && !prepared.expiresDisplay) {
+                prepared.expiresDisplay = formatDisplayDate(prepared.expires);
+            }
+            if (prepared.issued && !prepared.issuedDisplay) {
+                prepared.issuedDisplay = formatDisplayDate(prepared.issued);
+            }
+            if (!prepared.previewSource) {
+                const candidate = prepared.previewSource || prepared.dataUrl || prepared.url;
+                const source = candidate && candidate !== '#' ? candidate : '';
+                prepared.previewSource = source;
+            }
+            if (!prepared.fileName && prepared.url && prepared.url !== '#') {
+                prepared.fileName = prepared.url.split('/').pop();
+            }
+            prepared.canPreview = Boolean(prepared.previewSource);
+            return prepared;
+        }
+
+        function prepareEmployee(employee) {
+            return {
+                ...employee,
+                documents: (employee.documents || []).map(prepareDocument)
+            };
+        }
+
         const employees = [
             {
                 id: 'john-doe',
@@ -436,7 +534,15 @@
                     'VIP Lounge — Oct 12 (Setup & close)'
                 ],
                 documents: [
-                    { type: 'TABC Certificate', status: 'Active', expires: '2025-05-12', url: '#', attention: false },
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2023-05-12',
+                        expires: '2025-05-12',
+                        licenseNumber: 'TX-BC-4412',
+                        url: '#',
+                        attention: false
+                    },
                     { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
                 ]
             },
@@ -455,7 +561,15 @@
                     'Mocktail Workshop — Oct 22 (Program design)'
                 ],
                 documents: [
-                    { type: 'TABC Certificate', status: 'Expiring soon', expires: '2024-10-30', url: '#', attention: true },
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Expiring soon',
+                        issued: '2022-11-01',
+                        expires: '2024-10-30',
+                        licenseNumber: 'TX-ML-3008',
+                        url: '#',
+                        attention: true
+                    },
                     { type: 'Food Handler', status: 'Submitted', expires: '2026-02-01', url: '#', attention: false }
                 ]
             },
@@ -475,7 +589,15 @@
                     'Wedding Reception — Oct 15 (Bartender)'
                 ],
                 documents: [
-                    { type: 'TABC Certificate', status: 'Active', expires: '2026-01-19', url: '#', attention: false },
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2024-01-19',
+                        expires: '2026-01-19',
+                        licenseNumber: 'TX-RV-7782',
+                        url: '#',
+                        attention: false
+                    },
                     { type: 'Food Handler', status: 'Pending upload', expires: '—', url: '#', attention: true }
                 ]
             },
@@ -495,7 +617,15 @@
                     'Holiday Menu Lab — Nov 2 (Designer)'
                 ],
                 documents: [
-                    { type: 'TABC Certificate', status: 'Active', expires: '2025-11-08', url: '#', attention: false },
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2023-11-08',
+                        expires: '2025-11-08',
+                        licenseNumber: 'TX-PS-1150',
+                        url: '#',
+                        attention: false
+                    },
                     { type: 'W-9', status: 'On file', expires: '—', url: '#', attention: false }
                 ]
             },
@@ -514,7 +644,15 @@
                     'Mixology Workshop — Oct 18 (Support)'
                 ],
                 documents: [
-                    { type: 'TABC Certificate', status: 'Needs renewal', expires: '2024-09-25', url: '#', attention: true },
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Needs renewal',
+                        issued: '2022-09-25',
+                        expires: '2024-09-25',
+                        licenseNumber: 'TX-JL-8821',
+                        url: '#',
+                        attention: true
+                    },
                     { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
                 ]
             },
@@ -537,7 +675,7 @@
                     { type: 'Food Handler', status: 'Active', expires: '2025-03-15', url: '#', attention: false }
                 ]
             }
-        ];
+        ].map(prepareEmployee);
 
         const employeeList = document.getElementById('employeeList');
         const employeeDetails = document.getElementById('employeeDetails');
@@ -561,10 +699,24 @@
         const blastPreview = document.getElementById('blastPreview');
         const blastAlert = document.getElementById('blastAlert');
         const communicationForm = document.getElementById('communicationForm');
+        const docViewer = document.getElementById('docViewer');
+        const docViewerDialog = docViewer ? docViewer.querySelector('.modal__dialog') : null;
+        const docViewerTitle = document.getElementById('docViewerTitle');
+        const docViewerSubtitle = document.getElementById('docViewerSubtitle');
+        const docViewerMeta = document.getElementById('docViewerMeta');
+        const docViewerFrame = document.getElementById('docViewerFrame');
+        const docViewerPlaceholder = document.getElementById('docViewerPlaceholder');
+        const docViewerDownload = document.getElementById('docViewerDownload');
         const docForm = document.getElementById('uploadForm');
         const docTypeSelect = document.getElementById('docTypeSelect');
         const docFile = document.getElementById('docFile');
         const docAlert = document.getElementById('docAlert');
+        const tabcMetadata = document.getElementById('tabcMetadata');
+        const tabcMetadataHelper = document.getElementById('tabcMetadataHelper');
+        const tabcLicenseInput = document.getElementById('tabcLicense');
+        const tabcIssuedInput = document.getElementById('tabcIssued');
+        const tabcExpiresInput = document.getElementById('tabcExpires');
+        const docSubmitButton = docForm ? docForm.querySelector('button[type="submit"]') : null;
         const addEmployeeForm = document.getElementById('addEmployeeForm');
         const addEmployeeAlert = document.getElementById('addEmployeeAlert');
         const teamNameInput = document.getElementById('teamName');
@@ -588,6 +740,7 @@
         const SMS_LIMIT = 160;
 
         let selectedEmployeeId = null;
+        let docViewerPreviousFocus = null;
 
         function setAlert(element, message, tone = 'info') {
             if (!element) return;
@@ -604,6 +757,45 @@
                 element.classList.add('text-danger');
             } else {
                 element.classList.add('text-muted');
+            }
+        }
+
+        function toggleDocLoading(isLoading) {
+            if (!docSubmitButton) {
+                return;
+            }
+
+            docSubmitButton.disabled = isLoading;
+            if (isLoading) {
+                docSubmitButton.textContent = 'Saving…';
+            } else {
+                docSubmitButton.textContent = docSubmitDefaultText || 'Record document';
+            }
+        }
+
+        function updateDocMetadataVisibility() {
+            if (!docTypeSelect) {
+                return;
+            }
+
+            const isTabc = docTypeSelect.value.toLowerCase().includes('tabc');
+
+            if (tabcMetadata) {
+                tabcMetadata.hidden = !isTabc;
+                tabcMetadata.setAttribute('aria-hidden', String(!isTabc));
+            }
+
+            if (tabcMetadataHelper) {
+                tabcMetadataHelper.hidden = !isTabc;
+                tabcMetadataHelper.setAttribute('aria-hidden', String(!isTabc));
+            }
+
+            if (!isTabc) {
+                [tabcLicenseInput, tabcIssuedInput, tabcExpiresInput].forEach((input) => {
+                    if (input) {
+                        input.value = '';
+                    }
+                });
             }
         }
 
@@ -625,9 +817,163 @@
             return `${base || 'teammate'}-${suffix}`;
         }
 
+        function addDocViewerMeta(label, value) {
+            if (!docViewerMeta) {
+                return;
+            }
+
+            const dt = document.createElement('dt');
+            dt.textContent = label;
+            docViewerMeta.appendChild(dt);
+
+            const dd = document.createElement('dd');
+            dd.textContent = value || '—';
+            docViewerMeta.appendChild(dd);
+        }
+
+        function closeDocViewer() {
+            if (!docViewer) {
+                return;
+            }
+
+            docViewer.classList.remove('is-open');
+            docViewer.setAttribute('aria-hidden', 'true');
+            if (typeof document !== 'undefined' && document.body) {
+                document.body.classList.remove('modal-open');
+            }
+
+            if (docViewerFrame) {
+                docViewerFrame.removeAttribute('src');
+                docViewerFrame.hidden = true;
+            }
+
+            if (docViewerPlaceholder) {
+                docViewerPlaceholder.hidden = false;
+            }
+
+            if (docViewerDownload) {
+                docViewerDownload.href = '#';
+                docViewerDownload.setAttribute('aria-disabled', 'true');
+                docViewerDownload.classList.add('is-disabled');
+                docViewerDownload.tabIndex = -1;
+                docViewerDownload.removeAttribute('download');
+            }
+
+            if (docViewerMeta) {
+                docViewerMeta.innerHTML = '';
+            }
+
+            if (docViewerSubtitle) {
+                docViewerSubtitle.textContent = '';
+            }
+
+            if (docViewerTitle) {
+                docViewerTitle.textContent = 'Document preview';
+            }
+
+            if (docViewerPreviousFocus && typeof docViewerPreviousFocus.focus === 'function') {
+                docViewerPreviousFocus.focus();
+            }
+
+            docViewerPreviousFocus = null;
+        }
+
+        function openDocViewer(doc, employeeName) {
+            if (!doc) {
+                return;
+            }
+
+            const previewSource = doc.previewSource || doc.url || '';
+            const hasPreview = Boolean(previewSource);
+
+            if (!docViewer || !docViewerDialog) {
+                if (hasPreview) {
+                    window.open(previewSource, '_blank');
+                }
+                return;
+            }
+
+            docViewerPreviousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+            docViewer.classList.add('is-open');
+            docViewer.setAttribute('aria-hidden', 'false');
+            if (typeof document !== 'undefined' && document.body) {
+                document.body.classList.add('modal-open');
+            }
+
+            if (docViewerTitle) {
+                docViewerTitle.textContent = doc.type || 'Document preview';
+            }
+
+            if (docViewerSubtitle) {
+                const parts = [];
+                if (employeeName) {
+                    parts.push(employeeName);
+                }
+                if (doc.fileName) {
+                    parts.push(doc.fileName);
+                }
+                docViewerSubtitle.textContent = parts.join(' · ');
+            }
+
+            if (docViewerMeta) {
+                docViewerMeta.innerHTML = '';
+                addDocViewerMeta('Status', doc.status || '—');
+                addDocViewerMeta('Issued', ((doc.issuedDisplay || doc.issued || '') + '').trim() || '—');
+                addDocViewerMeta('Expires', ((doc.expiresDisplay || doc.expires || '') + '').trim() || '—');
+                addDocViewerMeta('License / ID', doc.licenseNumber || '—');
+                const uploadedLabel = formatDisplayDateTime(doc.uploadedAt);
+                if (uploadedLabel) {
+                    addDocViewerMeta('Uploaded', uploadedLabel);
+                }
+                if (doc.fileName) {
+                    addDocViewerMeta('File name', doc.fileName);
+                }
+            }
+
+            if (docViewerFrame) {
+                if (hasPreview) {
+                    docViewerFrame.src = previewSource;
+                    docViewerFrame.hidden = false;
+                } else {
+                    docViewerFrame.removeAttribute('src');
+                    docViewerFrame.hidden = true;
+                }
+            }
+
+            if (docViewerPlaceholder) {
+                docViewerPlaceholder.hidden = hasPreview;
+            }
+
+            if (docViewerDownload) {
+                if (hasPreview) {
+                    docViewerDownload.href = previewSource;
+                    docViewerDownload.removeAttribute('aria-disabled');
+                    docViewerDownload.classList.remove('is-disabled');
+                    docViewerDownload.tabIndex = 0;
+                    if (doc.fileName) {
+                        docViewerDownload.setAttribute('download', doc.fileName);
+                    } else {
+                        docViewerDownload.removeAttribute('download');
+                    }
+                } else {
+                    docViewerDownload.href = '#';
+                    docViewerDownload.setAttribute('aria-disabled', 'true');
+                    docViewerDownload.classList.add('is-disabled');
+                    docViewerDownload.tabIndex = -1;
+                    docViewerDownload.removeAttribute('download');
+                }
+            }
+
+            if (docViewerDialog) {
+                docViewerDialog.focus();
+            }
+        }
+
         let activeFilter = 'all';
         let suppressBlastAlertClear = false;
         let suppressDocAlertClear = false;
+        const docSubmitDefaultText = docSubmitButton ? docSubmitButton.textContent : '';
 
         function renderEmployeeList(list) {
             if (!employeeList) return;
@@ -708,8 +1054,9 @@
 
             detailDocs.innerHTML = '';
             if (employee.documents && employee.documents.length) {
-                employee.documents.forEach((doc) => {
+                employee.documents.forEach((doc, index) => {
                     const row = document.createElement('tr');
+                    row.dataset.docIndex = String(index);
 
                     const typeCell = document.createElement('td');
                     typeCell.textContent = doc.type;
@@ -722,21 +1069,53 @@
                     statusCell.appendChild(statusBadge);
                     row.appendChild(statusCell);
 
+                    const issuedCell = document.createElement('td');
+                    const issuedText = ((doc.issuedDisplay || doc.issued || '') + '').trim();
+                    issuedCell.textContent = issuedText || '—';
+                    row.appendChild(issuedCell);
+
                     const expiresCell = document.createElement('td');
-                    expiresCell.textContent = doc.expires && doc.expires.trim() ? doc.expires : '—';
+                    const expiresText = ((doc.expiresDisplay || doc.expires || '') + '').trim();
+                    expiresCell.textContent = expiresText || '—';
                     row.appendChild(expiresCell);
 
+                    const licenseCell = document.createElement('td');
+                    licenseCell.textContent = doc.licenseNumber || '—';
+                    row.appendChild(licenseCell);
+
                     const fileCell = document.createElement('td');
-                    if (doc.url) {
-                        const link = document.createElement('a');
-                        link.href = doc.url;
-                        link.textContent = doc.fileName || 'View';
-                        fileCell.appendChild(link);
-                    } else if (doc.fileName) {
-                        fileCell.textContent = doc.fileName;
-                    } else {
+                    const canPreview = Boolean(doc.previewSource);
+
+                    if (doc.fileName) {
+                        const nameSpan = document.createElement('span');
+                        nameSpan.className = 'doc-file-name';
+                        nameSpan.textContent = doc.fileName;
+                        fileCell.appendChild(nameSpan);
+                    }
+
+                    if (canPreview) {
+                        if (doc.fileName) {
+                            const separator = document.createElement('span');
+                            separator.className = 'doc-file-separator';
+                            separator.textContent = ' · ';
+                            fileCell.appendChild(separator);
+                        }
+
+                        const viewButton = document.createElement('button');
+                        viewButton.type = 'button';
+                        viewButton.className = 'link-button';
+                        viewButton.dataset.docAction = 'view';
+                        viewButton.textContent = 'View';
+                        fileCell.appendChild(viewButton);
+                    } else if (!doc.fileName) {
                         fileCell.textContent = '—';
                         fileCell.classList.add('text-muted');
+                    } else {
+                        const note = document.createElement('span');
+                        note.className = 'text-muted';
+                        note.textContent = 'No file on record';
+                        fileCell.appendChild(document.createElement('br'));
+                        fileCell.appendChild(note);
                     }
 
                     row.appendChild(fileCell);
@@ -745,7 +1124,7 @@
             } else {
                 const row = document.createElement('tr');
                 const cell = document.createElement('td');
-                cell.colSpan = 4;
+                cell.colSpan = 6;
                 cell.className = 'text-muted';
                 cell.textContent = 'No documentation on file yet.';
                 row.appendChild(cell);
@@ -767,6 +1146,35 @@
                     detailAssignments.appendChild(pill);
                 }
             }
+        }
+
+        if (detailDocs) {
+            detailDocs.addEventListener('click', (event) => {
+                const trigger = event.target instanceof Element ? event.target.closest('[data-doc-action="view"]') : null;
+                if (!trigger) {
+                    return;
+                }
+
+                event.preventDefault();
+
+                const row = trigger.closest('tr');
+                const employee = getSelectedEmployee();
+                if (!row || !employee) {
+                    return;
+                }
+
+                const index = Number.parseInt(row.dataset.docIndex || '', 10);
+                if (Number.isNaN(index)) {
+                    return;
+                }
+
+                const documentRecord = employee.documents ? employee.documents[index] : null;
+                if (!documentRecord) {
+                    return;
+                }
+
+                openDocViewer(documentRecord, employee.name);
+            });
         }
 
         function applyFilters() {
@@ -802,6 +1210,12 @@
             });
         });
 
+        if (docTypeSelect) {
+            docTypeSelect.addEventListener('change', updateDocMetadataVisibility);
+        }
+
+        updateDocMetadataVisibility();
+
         function buildComplianceLists() {
             const tabcExpiring = [];
             const foodPending = [];
@@ -810,7 +1224,9 @@
             employees.forEach((employee) => {
                 (employee.documents || []).forEach((doc) => {
                     if (doc.type === 'TABC Certificate' && doc.attention) {
-                        tabcExpiring.push(`${employee.name} — renew by ${doc.expires}`);
+                        const expiryLabel = doc.expiresDisplay || doc.expires || 'TBC';
+                        const licenseLabel = doc.licenseNumber ? ` (${doc.licenseNumber})` : '';
+                        tabcExpiring.push(`${employee.name}${licenseLabel} — renew by ${expiryLabel}`);
                     }
                     if (doc.type === 'Food Handler' && doc.attention) {
                         foodPending.push(`${employee.name} — pending upload`);
@@ -926,25 +1342,62 @@
                     return;
                 }
 
-                const fileName = file.name;
                 const isTabc = type.toLowerCase().includes('tabc');
-                const newDoc = {
-                    type,
-                    status: isTabc ? 'Needs review' : 'Submitted',
-                    expires: isTabc ? 'To be confirmed' : '—',
-                    attention: true,
-                    fileName,
-                    url: ''
-                };
+                const licenseValue = tabcLicenseInput ? tabcLicenseInput.value.trim() : '';
+                const issuedValue = tabcIssuedInput ? tabcIssuedInput.value : '';
+                const expiresValue = tabcExpiresInput ? tabcExpiresInput.value : '';
 
-                employee.documents = employee.documents || [];
-                employee.documents.push(newDoc);
+                if (isTabc && (!licenseValue || !issuedValue || !expiresValue)) {
+                    setAlert(
+                        docAlert,
+                        'Add the license ID along with issued and expiration dates for TABC uploads.',
+                        'danger'
+                    );
+                    return;
+                }
 
-                selectEmployee(employee.id);
-                suppressDocAlertClear = true;
-                docForm.reset();
-                setAlert(docAlert, `${type} saved for ${employee.name}.`, 'success');
-                buildComplianceLists();
+                if (typeof FileReader === 'undefined') {
+                    setAlert(docAlert, 'Your browser does not support file uploads here yet.', 'danger');
+                    return;
+                }
+
+                toggleDocLoading(true);
+                setAlert(docAlert, 'Processing document upload…', 'info');
+
+                const reader = new FileReader();
+                reader.addEventListener('load', () => {
+                    toggleDocLoading(false);
+                    const previewSource = typeof reader.result === 'string' ? reader.result : '';
+                    const record = prepareDocument({
+                        type,
+                        status: isTabc ? 'Needs review' : 'Submitted',
+                        issued: isTabc ? issuedValue : '',
+                        expires: isTabc ? expiresValue : '',
+                        licenseNumber: isTabc ? licenseValue : '',
+                        attention: true,
+                        fileName: file.name,
+                        previewSource,
+                        url: previewSource,
+                        uploadedAt: new Date().toISOString()
+                    });
+
+                    employee.documents = employee.documents || [];
+                    employee.documents.push(record);
+
+                    selectEmployee(employee.id);
+                    suppressDocAlertClear = true;
+                    docForm.reset();
+                    updateDocMetadataVisibility();
+                    buildComplianceLists();
+                    setAlert(docAlert, `${type} saved for ${employee.name}.`, 'success');
+                });
+
+                reader.addEventListener('error', () => {
+                    toggleDocLoading(false);
+                    setAlert(docAlert, 'We could not read that file. Try uploading again.', 'danger');
+                });
+
+                reader.readAsDataURL(file);
             });
 
             docForm.addEventListener('reset', () => {
@@ -952,8 +1405,30 @@
                     setAlert(docAlert, '');
                 }
                 suppressDocAlertClear = false;
+                toggleDocLoading(false);
+                updateDocMetadataVisibility();
             });
         }
+
+        if (docViewer) {
+            docViewer.addEventListener('click', (event) => {
+                const target = event.target;
+                if (!(target instanceof Element)) {
+                    return;
+                }
+
+                if (target.hasAttribute('data-modal-close')) {
+                    event.preventDefault();
+                    closeDocViewer();
+                }
+            });
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && docViewer && docViewer.classList.contains('is-open')) {
+                closeDocViewer();
+            }
+        });
 
         if (addEmployeeForm) {
             addEmployeeForm.addEventListener('submit', (event) => {

--- a/styles.css
+++ b/styles.css
@@ -930,6 +930,13 @@ textarea {
   display: block;
 }
 
+.form-grid--compact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
 .form-alert {
   font-size: 0.85rem;
   margin-top: 0.5rem;
@@ -1122,6 +1129,146 @@ textarea {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.is-open {
+  display: flex;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.modal__dialog {
+  position: relative;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: min(640px, calc(100% - 2rem));
+  max-height: calc(100% - 4rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+}
+
+.modal__dialog:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-weight: 600;
+}
+
+.modal__header {
+  padding-right: 2.5rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.modal__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+}
+
+.modal__details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+.modal__details dt {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--slate-600);
+}
+
+.modal__details dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--slate-800);
+}
+
+.modal__preview {
+  flex: 1 1 auto;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  min-height: 220px;
+}
+
+.modal__preview iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.modal__placeholder {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal__actions .button.is-disabled,
+.modal__actions .button[aria-disabled='true'],
+.modal__actions a.is-disabled {
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.doc-file-name {
+  font-weight: 500;
+}
+
+.doc-file-separator {
+  color: var(--slate-400);
+}
+
+.link-button.is-disabled,
+.link-button[disabled],
+.link-button[aria-disabled='true'] {
+  color: var(--slate-400);
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.button.is-disabled,
+.button[aria-disabled='true'] {
+  pointer-events: none;
+  opacity: 0.55;
 }
 
 @media (max-width: 960px) {
@@ -1382,6 +1529,15 @@ textarea {
   }
 
   .details-list {
+    grid-template-columns: 1fr;
+  }
+
+  .modal__dialog {
+    width: min(560px, calc(100% - 1.5rem));
+    padding: 1.25rem;
+  }
+
+  .modal__details {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- expose issued, expiration, and license metadata for TABC records in the employee documentation table
- add a document viewer modal and upload workflow that reads files for preview/download
- update seeded employee data and compliance messaging to surface TABC permit details

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68dedd9f657c8333b574d410a1d9addf