### PR TITLE
Fix syntax error preventing employee details from loading

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -628,7 +628,6 @@
             };
         }
 
-        const employees = [
         let employees = [
             {
                 id: 'john-doe',


### PR DESCRIPTION
## Summary
- remove an unused `const employees` declaration that introduced a syntax error in the employees page script
- allow the employees directory script to execute so selecting a teammate populates the details panel again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee349e4bc8333954d27f3e65b339e