### PR TITLE
Add interactive lead follow-up workflow

### DIFF
--- a/leads.html
+++ b/leads.html
@@ -71,53 +71,141 @@
                     <a class="card-action" href="#new-lead" data-subsection-target="new-lead">Add lead</a>
                 </div>
             </div>
-            <div class="table-wrapper">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Lead</th>
-                            <th>Event type</th>
-                            <th>Ideal date</th>
-                            <th>Estimated value</th>
-                            <th>Status</th>
-                            <th>Next touchpoint</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td data-label="Lead">Alicia Martinez · Corporate Mixer</td>
-                            <td data-label="Event type">Corporate</td>
-                            <td data-label="Ideal date">Nov 8, 2025</td>
-                            <td data-label="Estimated value"><span class="badge success">$3,500</span></td>
-                            <td data-label="Status"><span class="badge info">Proposal sent</span></td>
-                            <td data-label="Next touchpoint">Follow up on tasting preference</td>
-                        </tr>
-                        <tr>
-                            <td data-label="Lead">Danielle & Marcus · Wedding</td>
-                            <td data-label="Event type">Wedding</td>
-                            <td data-label="Ideal date">May 17, 2026</td>
-                            <td data-label="Estimated value"><span class="badge warning">$4,800</span></td>
-                            <td data-label="Status"><span class="badge warning">Awaiting deposit</span></td>
-                            <td data-label="Next touchpoint">Send deposit reminder</td>
-                        </tr>
-                        <tr>
-                            <td data-label="Lead">Houston Startup Hub</td>
-                            <td data-label="Event type">Launch party</td>
-                            <td data-label="Ideal date">Jan 12, 2026</td>
-                            <td data-label="Estimated value"><span class="badge success">$2,100</span></td>
-                            <td data-label="Status"><span class="badge neutral">Discovery call</span></td>
-                            <td data-label="Next touchpoint">Confirm guest count</td>
-                        </tr>
-                        <tr>
-                            <td data-label="Lead">Luxe Realty · Client Appreciation</td>
-                            <td data-label="Event type">Private event</td>
-                            <td data-label="Ideal date">Dec 9, 2025</td>
-                            <td data-label="Estimated value"><span class="badge success">$2,900</span></td>
-                            <td data-label="Status"><span class="badge success">Ready to book</span></td>
-                            <td data-label="Next touchpoint">Send contract draft</td>
-                        </tr>
-                    </tbody>
-                </table>
+            <div class="lead-pipeline__layout">
+                <div class="table-wrapper">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Lead</th>
+                                <th>Event type</th>
+                                <th>Ideal date</th>
+                                <th>Estimated value</th>
+                                <th>Status</th>
+                                <th>Next touchpoint</th>
+                            </tr>
+                        </thead>
+                        <tbody id="leadTableBody">
+                            <tr class="lead-table__empty">
+                                <td colspan="6">No leads logged yet.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <aside class="lead-detail" id="leadDetailPanel" aria-live="polite">
+                    <div class="lead-detail__empty" data-lead-empty>
+                        <h3>Select a lead to view the full history</h3>
+                        <p>Keep prospects moving by logging every touchpoint and updating the next best action.</p>
+                    </div>
+                    <div class="lead-detail__content" data-lead-content hidden>
+                        <header class="lead-detail__header">
+                            <div>
+                                <span class="badge" data-lead-field="status"></span>
+                                <h3 class="lead-detail__title" data-lead-field="name"></h3>
+                                <p class="lead-detail__subtitle" data-lead-field="company"></p>
+                            </div>
+                            <button class="button ghost small" type="button" data-lead-close>
+                                Close
+                            </button>
+                        </header>
+
+                        <div class="lead-detail__meta-grid">
+                            <article class="lead-detail__meta">
+                                <span class="lead-detail__meta-label">Next touchpoint</span>
+                                <p class="lead-detail__meta-value" data-lead-field="nextTouchpoint"></p>
+                            </article>
+                            <article class="lead-detail__meta">
+                                <span class="lead-detail__meta-label">Event date</span>
+                                <p class="lead-detail__meta-value" data-lead-field="eventDate"></p>
+                            </article>
+                            <article class="lead-detail__meta">
+                                <span class="lead-detail__meta-label">Est. value</span>
+                                <p class="lead-detail__meta-value" data-lead-field="estimatedValue"></p>
+                            </article>
+                            <article class="lead-detail__meta">
+                                <span class="lead-detail__meta-label">Last follow-up</span>
+                                <p class="lead-detail__meta-value" data-lead-field="lastFollowUp"></p>
+                            </article>
+                        </div>
+
+                        <section class="lead-detail__section lead-detail__contact">
+                            <h4 class="lead-detail__section-title">Contact</h4>
+                            <ul class="lead-detail__contact-list">
+                                <li>
+                                    <span>Email</span>
+                                    <a data-lead-field="email" href="#"></a>
+                                </li>
+                                <li>
+                                    <span>Phone</span>
+                                    <a data-lead-field="phone" href="#"></a>
+                                </li>
+                                <li>
+                                    <span>Source</span>
+                                    <p data-lead-field="source"></p>
+                                </li>
+                            </ul>
+                        </section>
+
+                        <section class="lead-detail__section">
+                            <h4 class="lead-detail__section-title">Notes</h4>
+                            <p class="lead-detail__notes" data-lead-field="notes"></p>
+                        </section>
+
+                        <section class="lead-detail__section">
+                            <div class="lead-detail__section-heading">
+                                <h4 class="lead-detail__section-title">Follow-up history</h4>
+                                <span class="lead-detail__history-count" data-lead-field="activityCount"></span>
+                            </div>
+                            <ul class="lead-activity-list" id="leadActivityList"></ul>
+                        </section>
+
+                        <section class="lead-detail__section">
+                            <h4 class="lead-detail__section-title">Log a follow-up</h4>
+                            <form class="lead-follow-up-form" id="leadFollowUpForm">
+                                <div class="form-grid">
+                                    <div class="form-field">
+                                        <label for="followUpMethod">Method</label>
+                                        <select id="followUpMethod" required>
+                                            <option value="Email">Email</option>
+                                            <option value="Phone">Phone call</option>
+                                            <option value="SMS">Text message</option>
+                                            <option value="Video call">Video call</option>
+                                            <option value="In-person">In-person meeting</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="followUpSchedule">Schedule next touchpoint</label>
+                                        <input id="followUpSchedule" type="datetime-local" />
+                                        <p class="form-helper-text">Optional: set when you plan to follow up next.</p>
+                                    </div>
+                                </div>
+
+                                <div class="form-field">
+                                    <label for="followUpMessage">Message sent</label>
+                                    <textarea
+                                        id="followUpMessage"
+                                        placeholder="Summarise what you sent or discussed."
+                                        required
+                                    ></textarea>
+                                </div>
+
+                                <div class="form-field">
+                                    <label for="followUpNextStep">Update next step</label>
+                                    <input
+                                        id="followUpNextStep"
+                                        type="text"
+                                        placeholder="E.g. Send revised proposal on Friday"
+                                    />
+                                </div>
+
+                                <div class="lead-follow-up-form__actions">
+                                    <p class="lead-follow-up-form__feedback" data-follow-up-feedback aria-live="polite"></p>
+                                    <button class="button primary" type="submit">Send follow-up</button>
+                                </div>
+                            </form>
+                        </section>
+                    </div>
+                </aside>
             </div>
         </section>
 
@@ -283,6 +371,8 @@
 
     <footer class="app-footer">© 2025 Bartending2U. Turning prospects into unforgettable celebrations.</footer>
 
+    <script src="storage.js"></script>
+    <script src="leads.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/leads.js
+++ b/leads.js
@@ -1,0 +1,442 @@
+(function () {
+    const store = window.B2UStore;
+    const tableBody = document.getElementById('leadTableBody');
+    const detailPanel = document.getElementById('leadDetailPanel');
+
+    if (!store || !tableBody || !detailPanel) {
+        return;
+    }
+
+    const detailContent = detailPanel.querySelector('[data-lead-content]');
+    const emptyState = detailPanel.querySelector('[data-lead-empty]');
+    const activityList = document.getElementById('leadActivityList');
+    const followUpForm = document.getElementById('leadFollowUpForm');
+    const followUpFeedback = detailPanel.querySelector('[data-follow-up-feedback]');
+    const closeButton = detailPanel.querySelector('[data-lead-close]');
+
+    const fieldRefs = {};
+    detailPanel.querySelectorAll('[data-lead-field]').forEach((element) => {
+        const key = element.getAttribute('data-lead-field');
+        if (!key) {
+            return;
+        }
+        fieldRefs[key] = element;
+    });
+
+    const state = {
+        leads: [],
+        selectedLeadId: null,
+        feedbackTimeoutId: null,
+    };
+
+    const dateFormatter = new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+
+    const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+
+    const currencyFormatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+    });
+
+    function formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '—';
+        }
+
+        return dateFormatter.format(date);
+    }
+
+    function formatDateTime(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '—';
+        }
+        return dateTimeFormatter.format(date);
+    }
+
+    function formatCurrency(value) {
+        const amount = Number(value);
+        if (!Number.isFinite(amount)) {
+            return '—';
+        }
+        return currencyFormatter.format(amount);
+    }
+
+    function formatLeadRowName(lead) {
+        if (!lead) {
+            return '';
+        }
+        return lead.company ? `${lead.name} · ${lead.company}` : lead.name;
+    }
+
+    function sortLeads(leads) {
+        return leads
+            .slice()
+            .sort((a, b) => {
+                const aTime = a && a.eventDate ? new Date(a.eventDate).getTime() : Number.POSITIVE_INFINITY;
+                const bTime = b && b.eventDate ? new Date(b.eventDate).getTime() : Number.POSITIVE_INFINITY;
+                if (aTime === bTime) {
+                    const aCreated = a && a.createdAt ? a.createdAt : 0;
+                    const bCreated = b && b.createdAt ? b.createdAt : 0;
+                    return bCreated - aCreated;
+                }
+                return aTime - bTime;
+            });
+    }
+
+    function renderTable() {
+        tableBody.innerHTML = '';
+
+        if (!state.leads.length) {
+            const emptyRow = document.createElement('tr');
+            emptyRow.className = 'lead-table__empty';
+            const cell = document.createElement('td');
+            cell.colSpan = 6;
+            cell.textContent = 'No leads logged yet.';
+            emptyRow.appendChild(cell);
+            tableBody.appendChild(emptyRow);
+            return;
+        }
+
+        state.leads.forEach((lead) => {
+            const row = document.createElement('tr');
+            row.className = 'lead-row';
+            if (lead.id === state.selectedLeadId) {
+                row.classList.add('is-selected');
+            }
+            row.dataset.leadId = lead.id;
+            row.tabIndex = 0;
+
+            const statusBadgeClass = ['badge'];
+            if (lead.statusLevel) {
+                statusBadgeClass.push(lead.statusLevel);
+            }
+
+            const valueBadgeClass = ['badge'];
+            if (lead.statusLevel === 'danger') {
+                valueBadgeClass.push('danger');
+            } else if (lead.statusLevel === 'warning') {
+                valueBadgeClass.push('warning');
+            } else {
+                valueBadgeClass.push('success');
+            }
+
+            row.innerHTML = `
+                <td data-label="Lead">${formatLeadRowName(lead)}</td>
+                <td data-label="Event type">${lead.eventType || '—'}</td>
+                <td data-label="Ideal date">${formatDate(lead.eventDate)}</td>
+                <td data-label="Estimated value"><span class="${valueBadgeClass.join(' ')}">${formatCurrency(
+                    lead.estimatedValue
+                )}</span></td>
+                <td data-label="Status"><span class="${statusBadgeClass.join(' ')}">${lead.status || '—'}</span></td>
+                <td data-label="Next touchpoint">${lead.nextTouchpoint || '—'}</td>
+            `;
+
+            row.addEventListener('click', () => {
+                selectLead(lead.id);
+            });
+
+            row.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    selectLead(lead.id);
+                }
+            });
+
+            tableBody.appendChild(row);
+        });
+    }
+
+    function updateRowSelection() {
+        tableBody.querySelectorAll('.lead-row').forEach((row) => {
+            const leadId = row.dataset.leadId;
+            if (!leadId) {
+                return;
+            }
+            if (leadId === state.selectedLeadId) {
+                row.classList.add('is-selected');
+            } else {
+                row.classList.remove('is-selected');
+            }
+        });
+    }
+
+    function renderActivities(lead) {
+        if (!activityList) {
+            return;
+        }
+
+        activityList.innerHTML = '';
+
+        if (!lead.activities || lead.activities.length === 0) {
+            const emptyItem = document.createElement('li');
+            emptyItem.className = 'lead-activity-list__empty';
+            emptyItem.textContent = 'No activity logged yet. Log a follow-up to build momentum.';
+            activityList.appendChild(emptyItem);
+            return;
+        }
+
+        lead.activities.forEach((activity) => {
+            const item = document.createElement('li');
+            item.className = 'lead-activity-list__item';
+
+            const header = document.createElement('div');
+            header.className = 'lead-activity-list__item-header';
+
+            const method = document.createElement('span');
+            method.className = 'lead-activity-list__method';
+            method.textContent = activity.method || activity.type || 'Follow-up';
+
+            const time = document.createElement('time');
+            time.className = 'lead-activity-list__time';
+            time.dateTime = new Date(activity.createdAt).toISOString();
+            time.textContent = formatDateTime(activity.createdAt);
+
+            header.appendChild(method);
+            header.appendChild(time);
+
+            const summary = document.createElement('p');
+            summary.className = 'lead-activity-list__summary';
+            summary.textContent = activity.summary || activity.type || 'Update logged';
+
+            const message = document.createElement('p');
+            message.className = 'lead-activity-list__message';
+            message.textContent = activity.message || '';
+
+            item.appendChild(header);
+            item.appendChild(summary);
+            if (message.textContent) {
+                item.appendChild(message);
+            }
+
+            if (activity.scheduledFor) {
+                const scheduled = document.createElement('p');
+                scheduled.className = 'lead-activity-list__scheduled';
+                scheduled.textContent = `Next touchpoint scheduled for ${formatDateTime(activity.scheduledFor)}`;
+                item.appendChild(scheduled);
+            }
+
+            activityList.appendChild(item);
+        });
+    }
+
+    function renderDetail(lead) {
+        if (!lead) {
+            state.selectedLeadId = null;
+            detailPanel.classList.remove('is-open');
+            if (detailContent) {
+                detailContent.hidden = true;
+            }
+            if (emptyState) {
+                emptyState.hidden = false;
+            }
+            updateRowSelection();
+            return;
+        }
+
+        if (emptyState) {
+            emptyState.hidden = true;
+        }
+        if (detailContent) {
+            detailContent.hidden = false;
+        }
+        detailPanel.classList.add('is-open');
+
+        if (fieldRefs.status) {
+            fieldRefs.status.textContent = lead.status || '—';
+            fieldRefs.status.className = `badge ${lead.statusLevel || 'info'}`;
+        }
+        if (fieldRefs.name) {
+            fieldRefs.name.textContent = lead.name || 'Untitled lead';
+        }
+        if (fieldRefs.company) {
+            fieldRefs.company.textContent = lead.company || lead.eventType || '';
+        }
+        if (fieldRefs.nextTouchpoint) {
+            fieldRefs.nextTouchpoint.textContent = lead.nextTouchpoint || '—';
+        }
+        if (fieldRefs.eventDate) {
+            fieldRefs.eventDate.textContent = formatDate(lead.eventDate);
+        }
+        if (fieldRefs.estimatedValue) {
+            fieldRefs.estimatedValue.textContent = formatCurrency(lead.estimatedValue);
+        }
+        if (fieldRefs.lastFollowUp) {
+            if (lead.lastFollowUpAt) {
+                const method = lead.lastFollowUpMethod ? ` via ${lead.lastFollowUpMethod}` : '';
+                fieldRefs.lastFollowUp.textContent = `${formatDateTime(lead.lastFollowUpAt)}${method}`;
+            } else {
+                fieldRefs.lastFollowUp.textContent = 'No follow-up logged yet';
+            }
+        }
+        if (fieldRefs.email) {
+            const email = lead.email || '';
+            fieldRefs.email.textContent = email || '—';
+            fieldRefs.email.href = email ? `mailto:${email}` : '#';
+        }
+        if (fieldRefs.phone) {
+            const phone = lead.phone || '';
+            fieldRefs.phone.textContent = phone || '—';
+            fieldRefs.phone.href = phone ? `tel:${phone.replace(/[^0-9+]/g, '')}` : '#';
+        }
+        if (fieldRefs.source) {
+            fieldRefs.source.textContent = lead.source || '—';
+        }
+        if (fieldRefs.notes) {
+            fieldRefs.notes.textContent = lead.notes || 'No notes captured yet.';
+        }
+        if (fieldRefs.activityCount) {
+            const count = Array.isArray(lead.activities) ? lead.activities.length : 0;
+            fieldRefs.activityCount.textContent = count ? `${count} touchpoint${count === 1 ? '' : 's'}` : 'No activity yet';
+        }
+
+        renderActivities(lead);
+        updateRowSelection();
+    }
+
+    function refreshLeads(options = {}) {
+        const previousSelection = options.preserveSelection ? state.selectedLeadId : null;
+        state.leads = sortLeads(store.getLeads());
+        renderTable();
+        if (previousSelection) {
+            state.selectedLeadId = previousSelection;
+            const selected = state.leads.find((lead) => lead.id === previousSelection);
+            renderDetail(selected || null);
+        }
+    }
+
+    function selectLead(leadId) {
+        if (!leadId) {
+            renderDetail(null);
+            return;
+        }
+
+        state.selectedLeadId = leadId;
+        const lead = state.leads.find((item) => item.id === leadId) || store.getLead(leadId);
+        renderDetail(lead || null);
+    }
+
+    function closeDetail() {
+        renderDetail(null);
+        if (emptyState) {
+            emptyState.hidden = false;
+        }
+    }
+
+    function showFeedback(message, tone = 'success') {
+        if (!followUpFeedback) {
+            return;
+        }
+
+        followUpFeedback.textContent = message;
+        followUpFeedback.dataset.tone = tone;
+
+        if (state.feedbackTimeoutId) {
+            window.clearTimeout(state.feedbackTimeoutId);
+        }
+
+        state.feedbackTimeoutId = window.setTimeout(() => {
+            if (followUpFeedback.dataset.tone === tone) {
+                followUpFeedback.textContent = '';
+                delete followUpFeedback.dataset.tone;
+            }
+        }, 4000);
+    }
+
+    function handleFollowUpSubmit(event) {
+        event.preventDefault();
+        if (!state.selectedLeadId) {
+            showFeedback('Select a lead before logging a follow-up.', 'warning');
+            return;
+        }
+
+        const methodField = document.getElementById('followUpMethod');
+        const scheduleField = document.getElementById('followUpSchedule');
+        const messageField = document.getElementById('followUpMessage');
+        const nextStepField = document.getElementById('followUpNextStep');
+
+        if (!messageField || !methodField) {
+            return;
+        }
+
+        const message = (messageField.value || '').trim();
+        if (!message) {
+            showFeedback('Add a brief summary of the follow-up you sent.', 'warning');
+            messageField.focus();
+            return;
+        }
+
+        const method = methodField.value || 'Email';
+        const nextStepRaw = nextStepField ? nextStepField.value.trim() : '';
+        const scheduleValue = scheduleField ? scheduleField.value : '';
+
+        let scheduledFor = null;
+        if (scheduleValue) {
+            const date = new Date(scheduleValue);
+            if (!Number.isNaN(date.getTime())) {
+                scheduledFor = date.toISOString();
+            }
+        }
+
+        const activity = {
+            method,
+            summary: `${method} follow-up sent`,
+            message,
+        };
+
+        if (scheduledFor) {
+            activity.scheduledFor = scheduledFor;
+        }
+
+        if (nextStepRaw) {
+            activity.nextTouchpoint = nextStepRaw;
+        } else if (scheduledFor) {
+            activity.nextTouchpoint = `Check in on ${formatDate(scheduledFor)}`;
+        }
+
+        const updatedLead = store.addLeadActivity(state.selectedLeadId, activity);
+        if (!updatedLead) {
+            showFeedback('Unable to record follow-up. Please try again.', 'danger');
+            return;
+        }
+
+        refreshLeads({ preserveSelection: true });
+        selectLead(updatedLead.id);
+
+        if (followUpForm) {
+            followUpForm.reset();
+        }
+
+        showFeedback('Follow-up logged and next step updated.');
+    }
+
+    refreshLeads();
+    renderDetail(null);
+
+    if (followUpForm) {
+        followUpForm.addEventListener('submit', handleFollowUpSubmit);
+    }
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeDetail);
+    }
+})();

--- a/storage.js
+++ b/storage.js
@@ -1,6 +1,8 @@
 (function (global) {
     const STORAGE_KEY = 'bartending2u-scheduler';
 
+    const now = Date.now();
+
     const defaultData = {
         events: [
             {
@@ -20,8 +22,8 @@
                 staffingLevel: 'success',
                 assignedTeam: ['emp-1', 'emp-3', 'emp-6'],
                 notes: 'Deposit received. Call time 6:00 PM.',
-                lastReminderSent: Date.now() - 1000 * 60 * 60 * 24,
-                createdAt: Date.now() - 1000 * 60 * 20,
+                lastReminderSent: now - 1000 * 60 * 60 * 24,
+                createdAt: now - 1000 * 60 * 20,
             },
             {
                 id: 'evt-2',
@@ -41,7 +43,7 @@
                 assignedTeam: [],
                 notes: 'Send reminder for deposit. Discuss signature cocktail list.',
                 lastReminderSent: null,
-                createdAt: Date.now() - 1000 * 60 * 60 * 3,
+                createdAt: now - 1000 * 60 * 60 * 3,
             },
             {
                 id: 'evt-3',
@@ -61,7 +63,7 @@
                 assignedTeam: ['emp-5'],
                 notes: 'Client reviewing updated package. Follow up Friday.',
                 lastReminderSent: null,
-                createdAt: Date.now() - 1000 * 60 * 60 * 10,
+                createdAt: now - 1000 * 60 * 60 * 10,
             },
             {
                 id: 'evt-4',
@@ -80,8 +82,8 @@
                 staffingLevel: 'success',
                 assignedTeam: ['emp-4'],
                 notes: 'Include mocktail options and allergy-friendly mixers.',
-                lastReminderSent: Date.now() - 1000 * 60 * 60 * 12,
-                createdAt: Date.now() - 1000 * 60 * 5,
+                lastReminderSent: now - 1000 * 60 * 60 * 12,
+                createdAt: now - 1000 * 60 * 5,
             },
         ],
         employees: [
@@ -94,7 +96,7 @@
                 status: 'Available',
                 statusLevel: 'success',
                 notes: 'Expert in corporate activations.',
-                createdAt: Date.now() - 1000 * 60 * 60,
+                createdAt: now - 1000 * 60 * 60,
             },
             {
                 id: 'emp-2',
@@ -105,7 +107,7 @@
                 status: 'On PTO',
                 statusLevel: 'warning',
                 notes: 'Out Oct 10 - Oct 16.',
-                createdAt: Date.now() - 1000 * 60 * 60 * 2,
+                createdAt: now - 1000 * 60 * 60 * 2,
             },
             {
                 id: 'emp-3',
@@ -116,7 +118,7 @@
                 status: 'Available',
                 statusLevel: 'success',
                 notes: 'Spanish/English. Comfortable with large crowds.',
-                createdAt: Date.now() - 1000 * 60 * 25,
+                createdAt: now - 1000 * 60 * 25,
             },
             {
                 id: 'emp-4',
@@ -127,7 +129,7 @@
                 status: 'Available',
                 statusLevel: 'success',
                 notes: 'Specializes in custom experiences.',
-                createdAt: Date.now() - 1000 * 60 * 15,
+                createdAt: now - 1000 * 60 * 15,
             },
             {
                 id: 'emp-5',
@@ -138,7 +140,7 @@
                 status: 'Limited hours',
                 statusLevel: 'warning',
                 notes: 'Available evenings only.',
-                createdAt: Date.now() - 1000 * 60 * 10,
+                createdAt: now - 1000 * 60 * 10,
             },
             {
                 id: 'emp-6',
@@ -149,7 +151,149 @@
                 status: 'Available',
                 statusLevel: 'success',
                 notes: 'Strong with load-in/load-out logistics.',
-                createdAt: Date.now() - 1000 * 60 * 45,
+                createdAt: now - 1000 * 60 * 45,
+            },
+        ],
+        leads: [
+            {
+                id: 'lead-1',
+                name: 'Alicia Martinez',
+                company: 'Corporate Mixer',
+                email: 'alicia@houstonmixers.com',
+                phone: '(555) 410-8800',
+                eventType: 'Corporate',
+                eventDate: '2025-11-08',
+                estimatedValue: 3500,
+                status: 'Proposal sent',
+                statusLevel: 'info',
+                source: 'Referral',
+                guestCount: 85,
+                notes: 'Enjoyed the live tasting. Interested in a zero-proof welcome drink.',
+                nextTouchpoint: 'Follow up on tasting preference',
+                createdAt: now - 1000 * 60 * 60 * 24 * 4,
+                lastFollowUpAt: now - 1000 * 60 * 60 * 20,
+                lastFollowUpMethod: 'Email',
+                activities: [
+                    {
+                        id: 'act-1',
+                        type: 'note',
+                        method: 'Email',
+                        summary: 'Shared tasting recap',
+                        message: 'Sent curated tasting recap with sample menu links.',
+                        createdAt: now - 1000 * 60 * 60 * 20,
+                    },
+                    {
+                        id: 'act-2',
+                        type: 'call',
+                        method: 'Phone',
+                        summary: 'Discovery call',
+                        message: 'Confirmed guest count and signature mocktail interest.',
+                        createdAt: now - 1000 * 60 * 60 * 48,
+                    },
+                ],
+            },
+            {
+                id: 'lead-2',
+                name: 'Danielle & Marcus',
+                company: 'Wedding',
+                email: 'celebrate@danielleandmarcus.com',
+                phone: '(555) 720-1099',
+                eventType: 'Wedding',
+                eventDate: '2026-05-17',
+                estimatedValue: 4800,
+                status: 'Awaiting deposit',
+                statusLevel: 'warning',
+                source: 'Website form',
+                guestCount: 160,
+                notes: 'Requested champagne tower and signature his & hers cocktails.',
+                nextTouchpoint: 'Send deposit reminder',
+                createdAt: now - 1000 * 60 * 60 * 24 * 8,
+                lastFollowUpAt: now - 1000 * 60 * 60 * 36,
+                lastFollowUpMethod: 'SMS',
+                activities: [
+                    {
+                        id: 'act-3',
+                        type: 'follow-up',
+                        method: 'SMS',
+                        summary: 'Sent deposit reminder',
+                        message: 'Texted deposit reminder with secure payment link.',
+                        createdAt: now - 1000 * 60 * 60 * 36,
+                    },
+                    {
+                        id: 'act-4',
+                        type: 'meeting',
+                        method: 'Video call',
+                        summary: 'Menu planning session',
+                        message: 'Finalised signature cocktails and champagne tower logistics.',
+                        createdAt: now - 1000 * 60 * 60 * 72,
+                    },
+                ],
+            },
+            {
+                id: 'lead-3',
+                name: 'Houston Startup Hub',
+                company: 'Launch Party',
+                email: 'events@houstonstartuphub.com',
+                phone: '(555) 930-4412',
+                eventType: 'Launch party',
+                eventDate: '2026-01-12',
+                estimatedValue: 2100,
+                status: 'Discovery call',
+                statusLevel: 'neutral',
+                source: 'Venue partner',
+                guestCount: 120,
+                notes: 'Needs thematic cocktails named after startup founders.',
+                nextTouchpoint: 'Confirm guest count',
+                createdAt: now - 1000 * 60 * 60 * 24 * 2,
+                lastFollowUpAt: now - 1000 * 60 * 60 * 8,
+                lastFollowUpMethod: 'Phone',
+                activities: [
+                    {
+                        id: 'act-5',
+                        type: 'call',
+                        method: 'Phone',
+                        summary: 'Discovery call held',
+                        message: 'Discussed vision and high-level budget. Awaiting guest count.',
+                        createdAt: now - 1000 * 60 * 60 * 8,
+                    },
+                ],
+            },
+            {
+                id: 'lead-4',
+                name: 'Luxe Realty',
+                company: 'Client Appreciation',
+                email: 'events@luxerealty.com',
+                phone: '(555) 640-7788',
+                eventType: 'Private event',
+                eventDate: '2025-12-09',
+                estimatedValue: 2900,
+                status: 'Ready to book',
+                statusLevel: 'success',
+                source: 'Referral',
+                guestCount: 90,
+                notes: 'Wants high-end whiskey tasting station and cigar pairing.',
+                nextTouchpoint: 'Send contract draft',
+                createdAt: now - 1000 * 60 * 60 * 24 * 5,
+                lastFollowUpAt: now - 1000 * 60 * 60 * 18,
+                lastFollowUpMethod: 'Email',
+                activities: [
+                    {
+                        id: 'act-6',
+                        type: 'follow-up',
+                        method: 'Email',
+                        summary: 'Sent proposal for approval',
+                        message: 'Shared detailed proposal with whiskey tasting upgrades.',
+                        createdAt: now - 1000 * 60 * 60 * 18,
+                    },
+                    {
+                        id: 'act-7',
+                        type: 'note',
+                        method: 'Internal',
+                        summary: 'Venue walkthrough complete',
+                        message: 'Visited venue and confirmed back-of-house access.',
+                        createdAt: now - 1000 * 60 * 60 * 30,
+                    },
+                ],
             },
         ],
     };
@@ -178,6 +322,123 @@
     let memoryStore = null;
     let cache = null;
 
+    function mapStatusLevel(value) {
+        if (!value) {
+            return 'neutral';
+        }
+
+        const lower = String(value).toLowerCase();
+
+        if (lower.includes('confirm') || lower.includes('ready') || lower.includes('won') || lower.includes('available')) {
+            return 'success';
+        }
+
+        if (lower.includes('await') || lower.includes('limited') || lower.includes('need') || lower.includes('scheduled')) {
+            return 'warning';
+        }
+
+        if (lower.includes('overdue') || lower.includes('behind') || lower.includes('lost')) {
+            return 'danger';
+        }
+
+        return 'info';
+    }
+
+    function hydrateLead(lead) {
+        const base = Object.assign(
+            {
+                activities: [],
+                estimatedValue: 0,
+            },
+            lead
+        );
+
+        if (!Array.isArray(base.activities)) {
+            base.activities = [];
+        }
+
+        base.activities = base.activities
+            .map((activity) => {
+                const activityBase = Object.assign(
+                    {
+                        id: generateId('act'),
+                        type: 'note',
+                        createdAt: Date.now(),
+                    },
+                    activity
+                );
+
+                if (!activityBase.method) {
+                    activityBase.method = 'Email';
+                }
+
+                return activityBase;
+            })
+            .sort((a, b) => b.createdAt - a.createdAt);
+
+        if (!base.statusLevel) {
+            base.statusLevel = mapStatusLevel(base.status);
+        }
+
+        return base;
+    }
+
+    function normalise(data) {
+        if (!data || typeof data !== 'object') {
+            return clone(defaultData);
+        }
+
+        const events = Array.isArray(data.events) ? data.events : defaultData.events;
+        const employees = Array.isArray(data.employees) ? data.employees : defaultData.employees;
+        const leads = Array.isArray(data.leads) ? data.leads : defaultData.leads;
+
+        const hydratedEvents = events.map((event) => {
+            const base = Object.assign(
+                {
+                    assignedStaffIds: [],
+                    assignedTeam: [],
+                    requiredStaff: 0,
+                    lastReminderSent: null,
+                },
+                event
+            );
+
+            if (!Array.isArray(base.assignedStaffIds)) {
+                base.assignedStaffIds = [];
+            }
+
+            if (!Array.isArray(base.assignedTeam)) {
+                base.assignedTeam = [];
+            }
+
+            if (!base.statusLevel) {
+                base.statusLevel = mapStatusLevel(base.status);
+            }
+
+            if (!base.staffingLevel) {
+                base.staffingLevel = mapStatusLevel(base.staffingStatus);
+            }
+
+            return base;
+        });
+
+        const hydratedEmployees = employees.map((employee) => {
+            const base = Object.assign({}, employee);
+            if (!base.statusLevel) {
+                base.statusLevel = mapStatusLevel(base.status);
+            }
+            return base;
+        });
+
+        const hydratedLeads = leads.map((lead) => hydrateLead(lead));
+
+        return {
+            events: hydratedEvents,
+            employees: hydratedEmployees,
+            leads: hydratedLeads,
+        };
+    }
+
     function readRaw() {
         if (cache) {
             return cache;
@@ -189,12 +450,7 @@
                 if (!raw) {
                     const seeded = clone(defaultData);
                     cache = seeded;
-                    try {
-                        global.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
-                    } catch (seedError) {
-                        console.warn('Unable to seed scheduler data to localStorage. Falling back to memory store.', seedError);
-                        memoryStore = clone(seeded);
-                    }
+                    global.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
                     return cache;
                 }
 
@@ -230,107 +486,10 @@
         memoryStore = clone(payload);
     }
 
-    function normalise(data) {
-        if (!data || typeof data !== 'object') {
-            return clone(defaultData);
-        }
-
-        const events = Array.isArray(data.events) ? data.events : clone(defaultData.events);
-        const employees = Array.isArray(data.employees) ? data.employees : clone(defaultData.employees);
-
-        const hydratedEvents = events.map((event) => {
-            const base = Object.assign(
-                {
-                    assignedStaffIds: [],
-                    requiredStaff: 0,
-                    lastReminderSent: null,
-                },
-                event
-            );
-
-            if (!base.statusLevel) {
-                base.statusLevel = mapStatusLevel(base.status);
-            }
-
-            if (!base.staffingLevel) {
-                base.staffingLevel = mapStatusLevel(base.staffingStatus);
-            }
-
-            if (!Array.isArray(base.assignedStaffIds)) {
-                base.assignedStaffIds = [];
-            }
-
-            return base;
-        });
-
-        const hydratedEmployees = employees.map((employee) => {
-            const base = Object.assign({}, employee);
-            if (!base.statusLevel) {
-                base.statusLevel = mapStatusLevel(base.status);
-            }
-            return base;
-        });
-
-        return {
-            events: hydratedEvents,
-            employees: hydratedEmployees,
-        const normalisedEvents = (Array.isArray(data.events) ? data.events : clone(defaultData.events)).map((event) => {
-            const next = Object.assign({}, event);
-            if (!next.statusLevel && next.status) {
-                next.statusLevel = mapStatusLevel(next.status);
-            }
-            if (!next.staffingLevel && next.staffingStatus) {
-                next.staffingLevel = mapStatusLevel(next.staffingStatus);
-            }
-            if (!Array.isArray(next.assignedTeam)) {
-                next.assignedTeam = [];
-            }
-            return next;
-        });
-
-        const normalisedEmployees = (Array.isArray(data.employees) ? data.employees : clone(defaultData.employees)).map((employee) => {
-            const next = Object.assign({}, employee);
-            if (!next.statusLevel && next.status) {
-                next.statusLevel = mapStatusLevel(next.status);
-            }
-            return next;
-        });
-
-        return {
-            events: normalisedEvents,
-            employees: normalisedEmployees,
-        };
-    }
-
     function generateId(prefix) {
         const randomPart = Math.random().toString(36).slice(2, 8);
         const timePart = Date.now().toString(36);
         return `${prefix}-${randomPart}-${timePart}`;
-    }
-
-    function mapStatusLevel(value) {
-        if (!value) {
-            return 'neutral';
-        }
-
-        const lower = value.toLowerCase();
-        if (lower.includes('unassign')) {
-            return 'danger';
-        }
-
-        if (lower.includes('confirm') || lower.includes('ready') || lower.includes('available') || lower.includes('staffed') || lower.includes('assign')) {
-            return 'success';
-        }
-
-        if (lower.includes('need') || lower.includes('limited') || lower.includes('await') || lower.includes('pto')) {
-            return 'warning';
-        }
-
-        if (lower.includes('overdue') || lower.includes('contract')) {
-            return 'danger';
-        }
-
-        return 'info';
     }
 
     const store = {
@@ -343,6 +502,16 @@
         getEmployees() {
             return clone(readRaw().employees);
         },
+        getLeads() {
+            return clone(readRaw().leads);
+        },
+        getLead(leadId) {
+            if (!leadId) {
+                return null;
+            }
+            const lead = readRaw().leads.find((item) => item.id === leadId);
+            return lead ? clone(lead) : null;
+        },
         saveSnapshot(next) {
             writeRaw(next);
         },
@@ -353,6 +522,7 @@
                     id: generateId('evt'),
                     createdAt: Date.now(),
                     assignedStaffIds: [],
+                    assignedTeam: [],
                     requiredStaff: 0,
                     lastReminderSent: null,
                 },
@@ -368,12 +538,11 @@
 
             snapshot.events.push(event);
             writeRaw(snapshot);
-            return event;
+            return clone(event);
         },
         removeEvent(eventId) {
             const snapshot = readRaw();
-            const nextEvents = snapshot.events.filter((event) => event.id !== eventId);
-            snapshot.events = nextEvents;
+            snapshot.events = snapshot.events.filter((event) => event.id !== eventId);
             writeRaw(snapshot);
         },
         updateEvent(eventId, updates) {
@@ -383,23 +552,20 @@
 
             const snapshot = readRaw();
             const index = snapshot.events.findIndex((event) => event.id === eventId);
-            const snapshot = readRaw();
-            const index = snapshot.events.findIndex((event) => event.id === eventId);
-
             if (index === -1) {
                 return null;
             }
 
             const current = snapshot.events[index];
-            const nextEvent = Object.assign({}, current, updates, {
+            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
+            const nextEvent = Object.assign({}, current, patch, {
                 updatedAt: Date.now(),
             });
 
-            if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+            if (Object.prototype.hasOwnProperty.call(patch, 'status')) {
                 nextEvent.statusLevel = mapStatusLevel(nextEvent.status);
             }
-
-            if (Object.prototype.hasOwnProperty.call(updates, 'staffingStatus')) {
+            if (Object.prototype.hasOwnProperty.call(patch, 'staffingStatus')) {
                 nextEvent.staffingLevel = mapStatusLevel(nextEvent.staffingStatus);
             }
 
@@ -438,21 +604,6 @@
                 updatedAt: Date.now(),
             });
 
-            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
-            const nextEvent = Object.assign({}, current, patch);
-
-            if (!nextEvent.statusLevel || (patch && Object.prototype.hasOwnProperty.call(patch, 'status'))) {
-                nextEvent.statusLevel = mapStatusLevel(nextEvent.status);
-            }
-
-            if (!nextEvent.staffingLevel || (patch && (Object.prototype.hasOwnProperty.call(patch, 'staffingStatus') || Object.prototype.hasOwnProperty.call(patch, 'staffingLevel')))) {
-                nextEvent.staffingLevel = mapStatusLevel(nextEvent.staffingStatus);
-            }
-
-            if (!Array.isArray(nextEvent.assignedTeam)) {
-                nextEvent.assignedTeam = [];
-            }
-
             snapshot.events[index] = nextEvent;
             writeRaw(snapshot);
             return clone(nextEvent);
@@ -473,13 +624,96 @@
 
             snapshot.employees.push(employee);
             writeRaw(snapshot);
-            return employee;
+            return clone(employee);
         },
         removeEmployee(employeeId) {
             const snapshot = readRaw();
-            const nextEmployees = snapshot.employees.filter((employee) => employee.id !== employeeId);
-            snapshot.employees = nextEmployees;
+            snapshot.employees = snapshot.employees.filter((employee) => employee.id !== employeeId);
             writeRaw(snapshot);
+        },
+        addLead(leadInput) {
+            const snapshot = readRaw();
+            const lead = hydrateLead(
+                Object.assign(
+                    {
+                        id: generateId('lead'),
+                        createdAt: Date.now(),
+                        activities: [],
+                    },
+                    leadInput
+                )
+            );
+
+            if (!lead.nextTouchpoint && lead.notes) {
+                lead.nextTouchpoint = 'Schedule follow-up';
+            }
+
+            snapshot.leads.push(lead);
+            writeRaw(snapshot);
+            return clone(lead);
+        },
+        updateLead(leadId, updates) {
+            if (!leadId) {
+                return null;
+            }
+
+            const snapshot = readRaw();
+            const index = snapshot.leads.findIndex((lead) => lead.id === leadId);
+            if (index === -1) {
+                return null;
+            }
+
+            const current = snapshot.leads[index];
+            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
+            const nextLead = hydrateLead(
+                Object.assign({}, current, patch, {
+                    updatedAt: Date.now(),
+                })
+            );
+
+            if (Object.prototype.hasOwnProperty.call(patch, 'status')) {
+                nextLead.statusLevel = mapStatusLevel(nextLead.status);
+            }
+
+            snapshot.leads[index] = nextLead;
+            writeRaw(snapshot);
+            return clone(nextLead);
+        },
+        addLeadActivity(leadId, activityInput) {
+            if (!leadId) {
+                return null;
+            }
+
+            const snapshot = readRaw();
+            const index = snapshot.leads.findIndex((lead) => lead.id === leadId);
+            if (index === -1) {
+                return null;
+            }
+
+            const current = snapshot.leads[index];
+            const activity = Object.assign(
+                {
+                    id: generateId('act'),
+                    type: 'follow-up',
+                    method: 'Email',
+                    summary: 'Follow-up logged',
+                    createdAt: Date.now(),
+                },
+                activityInput
+            );
+
+            const nextLead = hydrateLead(
+                Object.assign({}, current, {
+                    activities: [activity, ...current.activities],
+                    lastFollowUpAt: activity.createdAt,
+                    lastFollowUpMethod: activity.method,
+                    nextTouchpoint: activity.nextTouchpoint || current.nextTouchpoint,
+                })
+            );
+
+            snapshot.leads[index] = nextLead;
+            writeRaw(snapshot);
+            return clone(nextLead);
         },
         clearAll() {
             writeRaw(clone(defaultData));

--- a/styles.css
+++ b/styles.css
@@ -749,6 +749,238 @@ tr:hover td {
   background: rgba(59, 130, 246, 0.05);
 }
 
+.lead-pipeline__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .lead-pipeline__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    align-items: flex-start;
+    gap: 1.75rem;
+  }
+}
+
+.lead-detail {
+  background: var(--surface);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.lead-detail__empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--slate-500);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lead-detail__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.lead-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.lead-detail__title {
+  font-size: 1.3rem;
+  line-height: 1.3;
+}
+
+.lead-detail__subtitle {
+  color: var(--slate-500);
+  font-size: 0.95rem;
+  margin-top: 0.15rem;
+}
+
+.lead-detail__meta-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.lead-detail__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(37, 99, 235, 0.05);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+}
+
+.lead-detail__meta-label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--slate-500);
+}
+
+.lead-detail__meta-value {
+  font-weight: 600;
+  color: var(--slate-700);
+}
+
+.lead-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lead-detail__section-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.lead-detail__contact-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lead-detail__contact-list span {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--slate-500);
+  margin-bottom: 0.25rem;
+}
+
+.lead-detail__contact-list a,
+.lead-detail__contact-list p {
+  color: var(--slate-700);
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.lead-detail__notes {
+  color: var(--slate-600);
+  line-height: 1.6;
+}
+
+.lead-detail__section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.lead-detail__history-count {
+  font-size: 0.85rem;
+  color: var(--slate-500);
+}
+
+.lead-activity-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lead-activity-list__item {
+  background: rgba(37, 99, 235, 0.07);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.lead-activity-list__item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.lead-activity-list__method {
+  font-weight: 600;
+  color: var(--primary-600);
+}
+
+.lead-activity-list__time {
+  font-size: 0.85rem;
+  color: var(--slate-500);
+}
+
+.lead-activity-list__summary {
+  font-weight: 600;
+  color: var(--slate-700);
+}
+
+.lead-activity-list__message {
+  color: var(--slate-600);
+}
+
+.lead-activity-list__scheduled {
+  font-size: 0.85rem;
+  color: var(--slate-500);
+}
+
+.lead-activity-list__empty {
+  text-align: center;
+  padding: 1.2rem;
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  border-radius: 14px;
+  color: var(--slate-500);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.lead-follow-up-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.lead-follow-up-form__feedback {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.lead-follow-up-form__feedback[data-tone='success'] {
+  color: var(--success-500);
+}
+
+.lead-follow-up-form__feedback[data-tone='warning'] {
+  color: var(--warning-500);
+}
+
+.lead-follow-up-form__feedback[data-tone='danger'] {
+  color: var(--danger-500);
+}
+
+tbody tr.lead-row {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+tbody tr.lead-row.is-selected td {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+tbody tr.lead-row:focus-visible td {
+  outline: 2px solid var(--primary-500);
+  outline-offset: -2px;
+}
+
 .table-actions {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- replace the static lead pipeline markup with a dynamic table that loads from the shared store
- add a lead detail drawer that surfaces contact info, history, and a form to log follow-ups
- extend the storage layer with seed lead data and helper APIs plus styling for the new experience

## Testing
- node -e "require('./storage.js'); console.log('ok')"
- node -c leads.js

------
https://chatgpt.com/codex/tasks/task_e_68dee2d845d08333a3119364d722dc38