### PR TITLE
Add interactive compliance snapshot details

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -479,21 +479,46 @@
                 </div>
             </div>
             <div class="compliance-grid" id="complianceGrid">
-                <article class="compliance-item">
+                <article
+                    class="compliance-item"
+                    data-compliance="tabcExpiring"
+                    tabindex="0"
+                    role="button"
+                    aria-expanded="false"
+                >
                     <h3>TABC certificates</h3>
                     <p class="compliance-summary"><strong>12</strong> active · <span class="text-warning">2 expiring this month</span></p>
                     <ul class="compliance-list" id="tabcExpiring"></ul>
                 </article>
-                <article class="compliance-item">
+                <article
+                    class="compliance-item"
+                    data-compliance="foodHandlerPending"
+                    tabindex="0"
+                    role="button"
+                    aria-expanded="false"
+                >
                     <h3>Food handler</h3>
                     <p class="compliance-summary"><strong>9</strong> verified · <span class="text-muted">3 pending upload</span></p>
                     <ul class="compliance-list" id="foodHandlerPending"></ul>
                 </article>
-                <article class="compliance-item">
+                <article
+                    class="compliance-item"
+                    data-compliance="documentsAttention"
+                    tabindex="0"
+                    role="button"
+                    aria-expanded="false"
+                >
                     <h3>Documents needing attention</h3>
                     <p class="compliance-summary"><span class="text-warning">Follow up this week</span></p>
                     <ul class="compliance-list" id="documentsAttention"></ul>
                 </article>
+            </div>
+            <div class="compliance-detail-panel" id="complianceDetailPanel" aria-live="polite">
+                <h3 id="complianceDetailTitle">Select a compliance item</h3>
+                <p class="compliance-detail-summary text-muted" id="complianceDetailSummary">
+                    Choose a category above to review which documents need attention.
+                </p>
+                <ul class="compliance-detail-list" id="complianceDetailList" hidden></ul>
             </div>
         </section>
 
@@ -1008,6 +1033,124 @@
             foodHandlerPending: document.getElementById('foodHandlerPending'),
             documentsAttention: document.getElementById('documentsAttention')
         };
+        const complianceDetailPanel = document.getElementById('complianceDetailPanel');
+        const complianceDetailTitle = document.getElementById('complianceDetailTitle');
+        const complianceDetailSummary = document.getElementById('complianceDetailSummary');
+        const complianceDetailList = document.getElementById('complianceDetailList');
+        const complianceItems = Array.from(document.querySelectorAll('.compliance-item[data-compliance]'));
+        const complianceItemMap = new Map();
+        const complianceData = {};
+        let activeComplianceKey = null;
+
+        complianceItems.forEach((item) => {
+            const key = item.dataset.compliance;
+            if (!key) {
+                return;
+            }
+
+            complianceItemMap.set(key, item);
+
+            item.addEventListener('click', () => {
+                setActiveCompliance(key);
+            });
+
+            item.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    setActiveCompliance(key);
+                }
+            });
+        });
+
+        function renderComplianceDetail() {
+            if (!complianceDetailPanel || !complianceDetailTitle || !complianceDetailList) {
+                return;
+            }
+
+            const key = activeComplianceKey;
+            if (!key) {
+                complianceDetailPanel.classList.remove('has-selection');
+                complianceDetailTitle.textContent = 'Select a compliance item';
+                if (complianceDetailSummary) {
+                    complianceDetailSummary.textContent = 'Choose a category above to review which documents need attention.';
+                    complianceDetailSummary.hidden = false;
+                }
+                complianceDetailList.innerHTML = '';
+                complianceDetailList.hidden = true;
+                return;
+            }
+
+            const item = complianceItemMap.get(key);
+            const heading = item ? item.querySelector('h3') : null;
+            const summary = item ? item.querySelector('.compliance-summary') : null;
+            const entries = complianceData[key] || [];
+
+            complianceDetailPanel.classList.add('has-selection');
+            complianceDetailTitle.textContent = heading ? heading.textContent.trim() : 'Compliance details';
+
+            if (complianceDetailSummary) {
+                if (summary && summary.textContent.trim()) {
+                    complianceDetailSummary.textContent = summary.textContent.trim();
+                    complianceDetailSummary.hidden = false;
+                } else {
+                    complianceDetailSummary.hidden = true;
+                }
+            }
+
+            complianceDetailList.innerHTML = '';
+            complianceDetailList.hidden = false;
+
+            if (!entries.length) {
+                const li = document.createElement('li');
+                li.className = 'text-muted';
+                li.textContent = 'You\'re all caught up for now.';
+                complianceDetailList.appendChild(li);
+                return;
+            }
+
+            entries.forEach((value) => {
+                const li = document.createElement('li');
+                li.textContent = value;
+                complianceDetailList.appendChild(li);
+            });
+        }
+
+        function setActiveCompliance(key) {
+            if (!key) {
+                return;
+            }
+
+            if (activeComplianceKey === key) {
+                const current = complianceItemMap.get(activeComplianceKey);
+                if (current) {
+                    current.classList.remove('is-active');
+                    current.setAttribute('aria-expanded', 'false');
+                }
+                activeComplianceKey = null;
+                renderComplianceDetail();
+                return;
+            }
+
+            if (activeComplianceKey) {
+                const previous = complianceItemMap.get(activeComplianceKey);
+                if (previous) {
+                    previous.classList.remove('is-active');
+                    previous.setAttribute('aria-expanded', 'false');
+                }
+            }
+
+            const nextItem = complianceItemMap.get(key);
+            if (!nextItem) {
+                activeComplianceKey = null;
+                renderComplianceDetail();
+                return;
+            }
+
+            activeComplianceKey = key;
+            nextItem.classList.add('is-active');
+            nextItem.setAttribute('aria-expanded', 'true');
+            renderComplianceDetail();
+        }
 
         const statusClasses = {
             available: 'badge success',
@@ -1794,12 +1937,19 @@
                 const listElement = complianceLists[key];
                 if (!listElement) return;
                 listElement.innerHTML = '';
+                listElement.hidden = true;
+                listElement.setAttribute('aria-hidden', 'true');
+
+                complianceData[key] = [...items];
 
                 if (!items.length) {
                     const li = document.createElement('li');
                     li.className = 'text-muted';
                     li.textContent = 'Nothing pending right now.';
                     listElement.appendChild(li);
+                    if (activeComplianceKey === key) {
+                        renderComplianceDetail();
+                    }
                     return;
                 }
 
@@ -1808,6 +1958,10 @@
                     li.textContent = item;
                     listElement.appendChild(li);
                 });
+
+                if (activeComplianceKey === key) {
+                    renderComplianceDetail();
+                }
             });
         }
 

--- a/styles.css
+++ b/styles.css
@@ -1423,6 +1423,23 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.compliance-item:hover,
+.compliance-item:focus-visible {
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 12px 24px -16px rgba(30, 41, 59, 0.45);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.compliance-item.is-active {
+  border-color: rgba(99, 102, 241, 0.7);
+  box-shadow: 0 14px 28px -14px rgba(30, 41, 59, 0.5);
+  background: rgba(99, 102, 241, 0.08);
+  transform: translateY(-2px);
 }
 
 .compliance-item h3 {
@@ -1436,11 +1453,37 @@ textarea {
 }
 
 .compliance-list {
+  display: none;
+}
+
+.compliance-detail-panel {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: rgba(15, 23, 42, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compliance-detail-panel.has-selection {
+  border-color: rgba(99, 102, 241, 0.5);
+  box-shadow: 0 18px 34px -20px rgba(30, 41, 59, 0.55);
+}
+
+.compliance-detail-summary {
+  margin: 0;
+}
+
+.compliance-detail-list {
+  list-style: disc;
+  padding-left: 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.9rem;
-  color: var(--slate-600);
+  font-size: 0.92rem;
+  color: var(--slate-700);
 }
 
 .communication-form {


### PR DESCRIPTION
## Summary
- add interactive compliance snapshot detail panel that announces focused category details
- wire up compliance snapshot items for keyboard-friendly selection and toggling
- refresh styling so selections highlight and the inline lists stay hidden until selected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee37678ac8333908fa7a9c8c543b3