### PR TITLE
Fix employee persistence in team directory

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -628,8 +628,7 @@
             };
         }
 
-        const employees = [
-        let employees = [
+        const fallbackEmployees = [
             {
                 id: 'john-doe',
                 name: 'John Doe',
@@ -929,7 +928,62 @@
                     ]
                 }
             }
-        ].map(prepareEmployee);
+        ];
+
+        let employees = fallbackEmployees.map(prepareEmployee);
+        const store = window.B2UStore;
+        let scheduledEvents = [];
+
+        function stripDocumentComputedFields(document) {
+            const copy = Object.assign({}, document);
+            delete copy.expiresDisplay;
+            delete copy.issuedDisplay;
+            delete copy.canPreview;
+            return copy;
+        }
+
+        function serialiseEmployeeForStorage(employee) {
+            const plain = JSON.parse(JSON.stringify(employee));
+            if (Array.isArray(plain.documents)) {
+                plain.documents = plain.documents.map(stripDocumentComputedFields);
+            }
+            return plain;
+        }
+
+        function persistEmployees() {
+            if (!store) {
+                return;
+            }
+
+            try {
+                const snapshot = store.getSnapshot();
+                snapshot.employees = employees.map(serialiseEmployeeForStorage);
+                store.saveSnapshot(snapshot);
+                try {
+                    scheduledEvents = store.getEvents();
+                } catch (eventError) {
+                    scheduledEvents = Array.isArray(snapshot.events) ? snapshot.events : scheduledEvents;
+                }
+            } catch (error) {
+                console.warn('Unable to persist employees to storage.', error);
+            }
+        }
+
+        if (store) {
+            try {
+                const snapshot = store.getSnapshot();
+                scheduledEvents = Array.isArray(snapshot.events) ? snapshot.events : [];
+
+                if (Array.isArray(snapshot.employees) && snapshot.employees.length) {
+                    employees = snapshot.employees.map(prepareEmployee);
+                } else {
+                    persistEmployees();
+                }
+            } catch (error) {
+                console.warn('Unable to load scheduler data from storage. Using defaults.', error);
+                scheduledEvents = [];
+            }
+        }
 
         const employeeList = document.getElementById('employeeList');
         const employeeDetails = document.getElementById('employeeDetails');
@@ -1741,6 +1795,29 @@
         }
 
         updateDocMetadataVisibility();
+        function removeEmployeeRecord(employeeId) {
+            if (!employeeId) {
+                return false;
+            }
+
+            const exists = employees.some((employee) => employee.id === employeeId);
+            if (!exists) {
+                return false;
+            }
+
+            employees = employees.filter((employee) => employee.id !== employeeId);
+            if (selectedEmployeeId === employeeId) {
+                selectedEmployeeId = null;
+            }
+
+            persistEmployees();
+            applyFilters();
+            buildComplianceLists();
+            updateBlastPreview();
+            refresh({ reloadEvents: false });
+            return true;
+        }
+
         function removeSelectedEmployee() {
             const employee = getSelectedEmployee();
             if (!employee) {
@@ -1752,12 +1829,9 @@
                 return;
             }
 
-            employees = employees.filter((person) => person.id !== employee.id);
-            selectedEmployeeId = null;
-            setAlert(docAlert, '');
-            applyFilters();
-            buildComplianceLists();
-            updateBlastPreview();
+            if (removeEmployeeRecord(employee.id)) {
+                setAlert(docAlert, '');
+            }
         }
 
         if (removeEmployeeButton) {
@@ -1921,6 +1995,8 @@
                 portal.statusLabel = portal.statusLabel || 'Invite pending';
                 portal.inviteSentAt = new Date().toISOString();
                 updatePortalAccess(employee);
+                persistEmployees();
+                refresh({ reloadEvents: false });
 
                 const recipient = employee.email || employee.name || 'this teammate';
                 setAlert(portalAlert, `Portal invite has been re-sent to ${recipient}.`, 'success');
@@ -1988,6 +2064,8 @@
                     employee.documents.push(record);
 
                     selectEmployee(employee.id);
+                    persistEmployees();
+                    refresh({ reloadEvents: false });
                     suppressDocAlertClear = true;
                     docForm.reset();
                     updateDocMetadataVisibility();
@@ -2097,8 +2175,20 @@
                     documents: []
                 };
 
-                employees.push(newEmployee);
-                selectedEmployeeId = newEmployee.id;
+                let savedEmployee = newEmployee;
+                if (store) {
+                    try {
+                        savedEmployee = store.addEmployee(newEmployee);
+                    } catch (error) {
+                        console.warn('Unable to save employee to storage. Using local data only.', error);
+                        savedEmployee = newEmployee;
+                    }
+                }
+
+                const preparedEmployee = prepareEmployee(savedEmployee);
+                employees.push(preparedEmployee);
+                selectedEmployeeId = preparedEmployee.id;
+                persistEmployees();
                 addEmployeeForm.reset();
                 setAlert(addEmployeeAlert, `${name} has been added to the roster.`, 'success');
 
@@ -2111,6 +2201,7 @@
                 renderEmployeeList(employees);
                 buildComplianceLists();
                 updateBlastPreview();
+                refresh({ reloadEvents: false });
             });
 
             addEmployeeForm.addEventListener('reset', () => setAlert(addEmployeeAlert, ''));
@@ -2175,7 +2266,6 @@
         updateCharacterCount();
         updateBlastTypeVisibility();
         updateBlastPreview();
-        const store = window.B2UStore;
         const teamList = document.getElementById('teamList');
         const teamForm = document.getElementById('teamForm');
         const upcomingShifts = document.getElementById('upcomingShifts');
@@ -2228,14 +2318,6 @@
             }
 
             teamList.innerHTML = '';
-
-            if (!store) {
-                const message = document.createElement('p');
-                message.className = 'empty-state';
-                message.textContent = 'Unable to load staff directory. Refresh the page to retry.';
-                teamList.appendChild(message);
-                return;
-            }
 
             if (employees.length === 0) {
                 const message = document.createElement('p');
@@ -2346,14 +2428,6 @@
 
             upcomingShifts.innerHTML = '';
 
-            if (!store) {
-                const message = document.createElement('p');
-                message.className = 'empty-state';
-                message.textContent = 'Unable to load schedule previews.';
-                upcomingShifts.appendChild(message);
-                return;
-            }
-
             const upcomingEvents = events
                 .slice()
                 .sort((a, b) => getEventTimestamp(a) - getEventTimestamp(b))
@@ -2402,55 +2476,83 @@
             });
         }
 
-        function refresh() {
-            if (!store) {
-                renderTeamList([]);
-                renderUpcomingShifts([]);
-                updateStats([]);
-                return;
+        function refresh({ reloadEvents = true } = {}) {
+            if (store && reloadEvents) {
+                try {
+                    scheduledEvents = store.getEvents();
+                } catch (error) {
+                    console.warn('Unable to load events from storage.', error);
+                    scheduledEvents = [];
+                }
             }
 
-            const employees = store.getEmployees();
-            const events = store.getEvents();
             renderTeamList(employees);
             updateStats(employees);
-            renderUpcomingShifts(events);
+            renderUpcomingShifts(scheduledEvents);
         }
 
         if (teamList) {
             teamList.addEventListener('click', (event) => {
                 const target = event.target.closest('[data-remove-employee]');
-                if (!target || !store) {
+                if (!target) {
                     return;
                 }
 
-                store.removeEmployee(target.dataset.removeEmployee);
-                refresh();
+                const employeeId = target.dataset.removeEmployee;
+                const employee = employees.find((person) => person.id === employeeId);
+                if (!employee) {
+                    return;
+                }
+
+                const confirmed = window.confirm(`Remove ${employee.name} from your roster? This action cannot be undone.`);
+                if (!confirmed) {
+                    return;
+                }
+
+                removeEmployeeRecord(employeeId);
             });
         }
 
-        if (teamForm && store) {
+        if (teamForm) {
             teamForm.addEventListener('submit', (event) => {
                 event.preventDefault();
 
                 const data = new FormData(teamForm);
-                const statusOption = teamForm.teamStatus.options[teamForm.teamStatus.selectedIndex];
-
-                store.addEmployee({
+                const statusOption = teamForm.teamStatus ? teamForm.teamStatus.options[teamForm.teamStatus.selectedIndex] : null;
+                const quickEmployee = {
+                    id: generateEmployeeId((data.get('name') || '').trim() || 'teammate'),
                     name: (data.get('name') || '').trim() || 'Unnamed team member',
                     role: data.get('role') || '',
                     email: (data.get('email') || '').trim(),
                     phone: (data.get('phone') || '').trim(),
                     status: data.get('status') || 'Available',
+                    statusLabel: statusOption ? statusOption.textContent || statusOption.value : 'Available',
                     statusLevel: statusOption ? statusOption.dataset.level : undefined,
                     notes: (data.get('notes') || '').trim(),
-                });
+                };
 
+                let savedQuickEmployee = quickEmployee;
+                if (store) {
+                    try {
+                        savedQuickEmployee = store.addEmployee(quickEmployee);
+                    } catch (error) {
+                        console.warn('Unable to save quick-add employee to storage.', error);
+                        savedQuickEmployee = quickEmployee;
+                    }
+                }
+
+                const preparedQuickEmployee = prepareEmployee(savedQuickEmployee);
+                employees.push(preparedQuickEmployee);
+                selectedEmployeeId = preparedQuickEmployee.id;
+                persistEmployees();
                 teamForm.reset();
                 if (teamForm.teamStatus) {
                     teamForm.teamStatus.value = 'Available';
                 }
-                refresh();
+                refresh({ reloadEvents: false });
+                applyFilters();
+                buildComplianceLists();
+                updateBlastPreview();
             });
         }
 

--- a/storage.js
+++ b/storage.js
@@ -13,12 +13,12 @@
                 guestCount: 120,
                 payout: 3800,
                 requiredStaff: 4,
-                assignedStaffIds: ['emp-1', 'emp-3', 'emp-4', 'emp-6'],
+                assignedStaffIds: ['john-doe', 'alex-rivera', 'priya-singh', 'marcus-allen'],
                 status: 'Confirmed',
                 statusLevel: 'success',
                 staffingStatus: 'Fully staffed',
                 staffingLevel: 'success',
-                assignedTeam: ['emp-1', 'emp-3', 'emp-6'],
+                assignedTeam: ['john-doe', 'alex-rivera', 'priya-singh'],
                 notes: 'Deposit received. Call time 6:00 PM.',
                 lastReminderSent: Date.now() - 1000 * 60 * 60 * 24,
                 createdAt: Date.now() - 1000 * 60 * 20,
@@ -33,7 +33,7 @@
                 guestCount: 180,
                 payout: 5200,
                 requiredStaff: 5,
-                assignedStaffIds: ['emp-1', 'emp-4'],
+                assignedStaffIds: ['john-doe', 'priya-singh'],
                 status: 'Awaiting deposit',
                 statusLevel: 'warning',
                 staffingStatus: 'Needs 2 bartenders',
@@ -53,12 +53,12 @@
                 guestCount: 250,
                 payout: 7600,
                 requiredStaff: 8,
-                assignedStaffIds: ['emp-2', 'emp-5'],
+                assignedStaffIds: ['jane-smith', 'jamie-lee'],
                 status: 'Contract overdue',
                 statusLevel: 'danger',
                 staffingStatus: 'Partial coverage',
                 staffingLevel: 'warning',
-                assignedTeam: ['emp-5'],
+                assignedTeam: ['jamie-lee'],
                 notes: 'Client reviewing updated package. Follow up Friday.',
                 lastReminderSent: null,
                 createdAt: Date.now() - 1000 * 60 * 60 * 10,
@@ -73,12 +73,12 @@
                 guestCount: 25,
                 payout: 1400,
                 requiredStaff: 2,
-                assignedStaffIds: ['emp-3', 'emp-6'],
+                assignedStaffIds: ['alex-rivera', 'marcus-allen'],
                 status: 'Confirmed',
                 statusLevel: 'success',
                 staffingStatus: 'Ready',
                 staffingLevel: 'success',
-                assignedTeam: ['emp-4'],
+                assignedTeam: ['priya-singh'],
                 notes: 'Include mocktail options and allergy-friendly mixers.',
                 lastReminderSent: Date.now() - 1000 * 60 * 60 * 12,
                 createdAt: Date.now() - 1000 * 60 * 5,
@@ -86,76 +86,445 @@
         ],
         employees: [
             {
-                id: 'emp-1',
+                id: 'john-doe',
                 name: 'John Doe',
-                role: 'Bar Lead · Flair certified',
+                role: 'Bar Lead',
+                specialties: 'Flair certified · High-volume service',
+                status: 'available',
+                statusLabel: 'Available',
+                location: 'Houston, TX',
                 email: 'john.doe@bartending2u.com',
-                phone: '(555) 100-2000',
-                status: 'Available',
-                statusLevel: 'success',
-                notes: 'Expert in corporate activations.',
-                createdAt: Date.now() - 1000 * 60 * 60,
+                phone: '(713) 555-0114',
+                addressLine1: '1901 Market St',
+                addressLine2: 'Suite 210',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77002',
+                taxId: '123-45-6789',
+                dob: '1984-07-19',
+                dlNumber: 'TX12345678',
+                dlState: 'TX',
+                notes: 'Lead trainer for new hires. Loves crafting signature welcome cocktails.',
+                assignments: [
+                    'Corporate Party — Oct 5 (Lead bartender)',
+                    'VIP Lounge — Oct 12 (Setup & close)'
+                ],
+                documents: [
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2023-05-12',
+                        expires: '2025-05-12',
+                        licenseNumber: 'TX-BC-4412',
+                        url: '#',
+                        attention: false
+                    },
+                    { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Full portal access',
+                    inviteSentAt: '2024-06-20T15:30:00',
+                    lastLogin: '2025-10-01T09:42:00',
+                    mfaEnabled: true,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-10-01T09:42:00', action: 'Logged in on desktop', location: 'Houston, TX' },
+                        { timestamp: '2025-09-28T17:22:00', action: 'Reviewed corporate party schedule', location: 'Houston, TX' },
+                        { timestamp: '2025-09-26T11:08:00', action: 'Downloaded pay stub', location: 'Mobile · Austin, TX' }
+                    ]
+                }
             },
             {
-                id: 'emp-2',
+                id: 'jane-smith',
                 name: 'Jane Smith',
-                role: 'Mixologist · Mocktail specialist',
+                role: 'Mixologist',
+                specialties: 'Mocktail specialist · Low ABV menus',
+                status: 'pto',
+                statusLabel: 'On PTO',
+                location: 'Austin, TX',
                 email: 'jane.smith@bartending2u.com',
-                phone: '(555) 222-3333',
-                status: 'On PTO',
-                statusLevel: 'warning',
-                notes: 'Out Oct 10 - Oct 16.',
-                createdAt: Date.now() - 1000 * 60 * 60 * 2,
+                phone: '(512) 555-0199',
+                addressLine1: '501 Congress Ave',
+                addressLine2: 'Apt 9B',
+                addressCity: 'Austin',
+                addressState: 'TX',
+                addressPostalCode: '78701',
+                taxId: '234-56-7890',
+                dob: '1990-02-11',
+                dlNumber: 'TX87654321',
+                dlState: 'TX',
+                notes: 'Certified sommelier. Currently on PTO returning Oct 14.',
+                assignments: [
+                    'Mocktail Workshop — Oct 22 (Program design)'
+                ],
+                documents: [
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Expiring soon',
+                        issued: '2022-11-01',
+                        expires: '2024-10-30',
+                        licenseNumber: 'TX-ML-3008',
+                        url: '#',
+                        attention: true
+                    },
+                    { type: 'Food Handler', status: 'Submitted', expires: '2026-02-01', url: '#', attention: false }
+                ],
+                portal: {
+                    status: 'invite-pending',
+                    statusLabel: 'Invite pending',
+                    statusLevel: 'warning',
+                    accessLevel: 'Awaiting portal activation',
+                    inviteSentAt: '2025-09-20T13:15:00',
+                    lastLogin: null,
+                    mfaEnabled: false,
+                    canResetPassword: false,
+                    canResendInvite: true,
+                    loginActivity: []
+                }
             },
             {
-                id: 'emp-3',
+                id: 'alex-rivera',
                 name: 'Alex Rivera',
-                role: 'Bartender · Bilingual',
+                role: 'Bartender',
+                specialties: 'Bilingual · Large format batching',
+                status: 'available',
+                statusLabel: 'Available',
+                location: 'Dallas, TX',
                 email: 'alex.rivera@bartending2u.com',
-                phone: '(555) 444-5555',
-                status: 'Available',
-                statusLevel: 'success',
-                notes: 'Spanish/English. Comfortable with large crowds.',
-                createdAt: Date.now() - 1000 * 60 * 25,
+                phone: '(469) 555-0147',
+                addressLine1: '1400 Elm St',
+                addressLine2: '',
+                addressCity: 'Dallas',
+                addressState: 'TX',
+                addressPostalCode: '75202',
+                taxId: '345-67-8901',
+                dob: '1988-11-03',
+                dlNumber: 'TX44556677',
+                dlState: 'TX',
+                notes: 'Lead for sports stadium activations. Fluent in Spanish and English.',
+                assignments: [
+                    'Corporate Party — Oct 5 (Support)',
+                    'Wedding Reception — Oct 15 (Bartender)'
+                ],
+                documents: [
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2024-01-19',
+                        expires: '2026-01-19',
+                        licenseNumber: 'TX-RV-7782',
+                        url: '#',
+                        attention: false
+                    },
+                    { type: 'Food Handler', status: 'Pending upload', expires: '—', url: '#', attention: true }
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Schedule + pay stubs',
+                    inviteSentAt: '2024-08-05T10:05:00',
+                    lastLogin: '2025-09-30T18:10:00',
+                    mfaEnabled: false,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-30T18:10:00', action: 'Logged in on mobile', location: 'Dallas, TX' },
+                        { timestamp: '2025-09-27T08:55:00', action: 'Confirmed shift availability', location: 'Dallas, TX' }
+                    ]
+                }
             },
             {
-                id: 'emp-4',
+                id: 'priya-singh',
                 name: 'Priya Singh',
-                role: 'Mixology Lead · Seasonal menu',
+                role: 'Mixology Lead',
+                specialties: 'Seasonal menu design · Training',
+                status: 'available',
+                statusLabel: 'Available',
+                location: 'Houston, TX',
                 email: 'priya.singh@bartending2u.com',
-                phone: '(555) 777-8888',
-                status: 'Available',
-                statusLevel: 'success',
-                notes: 'Specializes in custom experiences.',
-                createdAt: Date.now() - 1000 * 60 * 15,
+                phone: '(832) 555-0177',
+                addressLine1: '2220 Westheimer Rd',
+                addressLine2: 'Unit 5',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77098',
+                taxId: '456-78-9012',
+                dob: '1986-05-27',
+                dlNumber: 'TX99887766',
+                dlState: 'TX',
+                notes: 'Hosts quarterly workshops and champions zero-proof menu innovation.',
+                assignments: [
+                    'Mixology Workshop — Oct 18 (Instructor)',
+                    'Holiday Menu Lab — Nov 2 (Designer)'
+                ],
+                documents: [
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Active',
+                        issued: '2023-11-08',
+                        expires: '2025-11-08',
+                        licenseNumber: 'TX-PS-1150',
+                        url: '#',
+                        attention: false
+                    },
+                    { type: 'W-9', status: 'On file', expires: '—', url: '#', attention: false }
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Manager access',
+                    inviteSentAt: '2023-12-12T09:00:00',
+                    lastLogin: '2025-09-29T07:30:00',
+                    mfaEnabled: true,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-29T07:30:00', action: 'Approved workshop roster', location: 'Houston, TX' },
+                        { timestamp: '2025-09-25T19:05:00', action: 'Sent message to mixology team', location: 'Houston, TX' },
+                        { timestamp: '2025-09-21T12:18:00', action: 'Updated availability', location: 'Mobile · Austin, TX' }
+                    ]
+                }
             },
             {
-                id: 'emp-5',
+                id: 'jamie-lee',
                 name: 'Jamie Lee',
-                role: 'Support · Prep specialist',
+                role: 'Support',
+                specialties: 'Prep specialist · Logistics',
+                status: 'limited',
+                statusLabel: 'Limited hours',
+                location: 'San Antonio, TX',
                 email: 'jamie.lee@bartending2u.com',
-                phone: '(555) 999-1212',
-                status: 'Limited hours',
-                statusLevel: 'warning',
-                notes: 'Available evenings only.',
-                createdAt: Date.now() - 1000 * 60 * 10,
+                phone: '(210) 555-0188',
+                addressLine1: '815 Avenue B',
+                addressLine2: '',
+                addressCity: 'San Antonio',
+                addressState: 'TX',
+                addressPostalCode: '78215',
+                taxId: '567-89-0123',
+                dob: '1992-09-14',
+                dlNumber: 'TX11223344',
+                dlState: 'TX',
+                notes: 'Available for load-ins and barback duties Thursdays through Sundays.',
+                assignments: [
+                    'Mixology Workshop — Oct 18 (Support)'
+                ],
+                documents: [
+                    {
+                        type: 'TABC Certificate',
+                        status: 'Needs renewal',
+                        issued: '2022-09-25',
+                        expires: '2024-09-25',
+                        licenseNumber: 'TX-JL-8821',
+                        url: '#',
+                        attention: true
+                    },
+                    { type: 'Liability Waiver', status: 'On file', expires: '—', url: '#', attention: false }
+                ],
+                portal: {
+                    status: 'disabled',
+                    statusLabel: 'Access disabled',
+                    statusLevel: 'danger',
+                    accessLevel: 'Portal locked until renewal',
+                    inviteSentAt: '2024-02-10T16:45:00',
+                    lastLogin: '2024-08-18T14:05:00',
+                    mfaEnabled: false,
+                    canResetPassword: false,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2024-08-18T14:05:00', action: 'Account locked after credential expiration', location: 'San Antonio, TX' }
+                    ]
+                }
             },
             {
-                id: 'emp-6',
+                id: 'marcus-allen',
                 name: 'Marcus Allen',
                 role: 'Barback',
+                specialties: 'Inventory & breakdown',
+                status: 'available',
+                statusLabel: 'Available',
+                location: 'Houston, TX',
                 email: 'marcus.allen@bartending2u.com',
-                phone: '(555) 313-1414',
-                status: 'Available',
-                statusLevel: 'success',
-                notes: 'Strong with load-in/load-out logistics.',
-                createdAt: Date.now() - 1000 * 60 * 45,
-            },
+                phone: '(713) 555-0160',
+                addressLine1: '3710 Main St',
+                addressLine2: '',
+                addressCity: 'Houston',
+                addressState: 'TX',
+                addressPostalCode: '77002',
+                taxId: '678-90-1234',
+                dob: '1987-03-08',
+                dlNumber: 'TX55667788',
+                dlState: 'TX',
+                notes: 'Great with tight timelines and closing shifts. CDL certified.',
+                assignments: [
+                    'Wedding Reception — Oct 15 (Barback)',
+                    'Corporate Holiday Preview — Oct 28 (Inventory)'
+                ],
+                documents: [
+                    { type: 'Food Handler', status: 'Active', expires: '2025-03-15', url: '#', attention: false }
+                ],
+                portal: {
+                    status: 'active',
+                    statusLabel: 'Active',
+                    statusLevel: 'success',
+                    accessLevel: 'Schedule access only',
+                    inviteSentAt: '2025-01-12T08:30:00',
+                    lastLogin: '2025-09-24T06:55:00',
+                    mfaEnabled: false,
+                    canResetPassword: true,
+                    canResendInvite: false,
+                    loginActivity: [
+                        { timestamp: '2025-09-24T06:55:00', action: 'Checked load-in checklist', location: 'Houston, TX' },
+                        { timestamp: '2025-09-18T20:40:00', action: 'Confirmed transportation availability', location: 'Mobile · Houston, TX' }
+                    ]
+                }
+            }
         ],
     };
 
-    function clone(data) {
-        return JSON.parse(JSON.stringify(data));
+    function clone(value) {
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function toTitleCase(value) {
+        if (!value) {
+            return '';
+        }
+        return value.replace(/\b([a-z])/gi, (match) => match.toUpperCase());
+    }
+
+    function mapStatusLevel(value) {
+        if (!value) {
+            return 'neutral';
+        }
+        const lower = value.toLowerCase();
+        if (lower.includes('confirm') || lower.includes('ready') || lower.includes('available') || lower.includes('staffed')) {
+            return 'success';
+        }
+        if (lower.includes('need') || lower.includes('limited') || lower.includes('await') || lower.includes('pto') || lower.includes('pending')) {
+            return 'warning';
+        }
+        if (lower.includes('overdue') || lower.includes('contract') || lower.includes('booked') || lower.includes('disabled') || lower.includes('locked')) {
+            return 'danger';
+        }
+        return 'info';
+    }
+
+    function normaliseDocument(document) {
+        const base = Object.assign(
+            {
+                type: 'Document',
+                status: 'On file',
+                attention: false,
+                url: '#',
+            },
+            document || {}
+        );
+        return base;
+    }
+
+    function normalisePortal(portal) {
+        const base = Object.assign(
+            {
+                status: 'invite-pending',
+                statusLabel: 'Invite pending',
+                statusLevel: 'warning',
+                accessLevel: 'Awaiting activation',
+                inviteSentAt: null,
+                lastLogin: null,
+                mfaEnabled: false,
+                canResetPassword: false,
+                canResendInvite: false,
+                loginActivity: [],
+            },
+            portal || {}
+        );
+
+        if (!base.statusLabel) {
+            base.statusLabel = toTitleCase(base.status);
+        }
+        if (!base.statusLevel) {
+            base.statusLevel = mapStatusLevel(base.status);
+        }
+
+        base.loginActivity = Array.isArray(base.loginActivity) ? base.loginActivity.slice() : [];
+        return base;
+    }
+
+    function normaliseEmployee(employee) {
+        const base = Object.assign(
+            {
+                id: generateId('emp'),
+                createdAt: Date.now(),
+                status: 'available',
+                statusLabel: 'Available',
+                notes: '',
+                assignments: [],
+                documents: [],
+                portal: {},
+            },
+            employee || {}
+        );
+
+        if (!base.statusLabel) {
+            base.statusLabel = toTitleCase(base.status);
+        }
+        if (!base.statusLevel) {
+            base.statusLevel = mapStatusLevel(base.statusLabel || base.status);
+        }
+
+        base.assignments = Array.isArray(base.assignments) ? base.assignments.slice() : [];
+        base.documents = Array.isArray(base.documents) ? base.documents.map(normaliseDocument) : [];
+        base.portal = normalisePortal(base.portal);
+
+        return base;
+    }
+
+    function normaliseEvent(event) {
+        const base = Object.assign(
+            {
+                id: generateId('evt'),
+                createdAt: Date.now(),
+                assignedStaffIds: [],
+                assignedTeam: [],
+                requiredStaff: 0,
+                status: 'Draft',
+                staffingStatus: 'Unassigned',
+                lastReminderSent: null,
+            },
+            event || {}
+        );
+
+        if (!Array.isArray(base.assignedStaffIds)) {
+            base.assignedStaffIds = [];
+        }
+        if (!Array.isArray(base.assignedTeam)) {
+            base.assignedTeam = [];
+        }
+        if (!base.statusLevel) {
+            base.statusLevel = mapStatusLevel(base.status);
+        }
+        if (!base.staffingLevel) {
+            base.staffingLevel = mapStatusLevel(base.staffingStatus);
+        }
+
+        return base;
+    }
+
+    function normalise(snapshot) {
+        if (!snapshot || typeof snapshot !== 'object') {
+            return clone(defaultData);
+        }
+
+        const events = Array.isArray(snapshot.events) ? snapshot.events.map(normaliseEvent) : clone(defaultData.events);
+        const employees = Array.isArray(snapshot.employees) ? snapshot.employees.map(normaliseEmployee) : clone(defaultData.employees);
+
+        return { events, employees };
     }
 
     function localStorageAvailable() {
@@ -164,7 +533,6 @@
             if (!storage) {
                 return false;
             }
-
             const testKey = `${STORAGE_KEY}__test`;
             storage.setItem(testKey, '1');
             storage.removeItem(testKey);
@@ -186,21 +554,10 @@
         if (hasLocalStorage) {
             try {
                 const raw = global.localStorage.getItem(STORAGE_KEY);
-                if (!raw) {
-                    const seeded = clone(defaultData);
-                    cache = seeded;
-                    try {
-                        global.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
-                    } catch (seedError) {
-                        console.warn('Unable to seed scheduler data to localStorage. Falling back to memory store.', seedError);
-                        memoryStore = clone(seeded);
-                    }
+                if (raw) {
+                    cache = normalise(JSON.parse(raw));
                     return cache;
                 }
-
-                const parsed = JSON.parse(raw);
-                cache = normalise(parsed);
-                return cache;
             } catch (error) {
                 console.warn('Unable to read scheduler data from localStorage. Using in-memory fallback.', error);
             }
@@ -230,107 +587,10 @@
         memoryStore = clone(payload);
     }
 
-    function normalise(data) {
-        if (!data || typeof data !== 'object') {
-            return clone(defaultData);
-        }
-
-        const events = Array.isArray(data.events) ? data.events : clone(defaultData.events);
-        const employees = Array.isArray(data.employees) ? data.employees : clone(defaultData.employees);
-
-        const hydratedEvents = events.map((event) => {
-            const base = Object.assign(
-                {
-                    assignedStaffIds: [],
-                    requiredStaff: 0,
-                    lastReminderSent: null,
-                },
-                event
-            );
-
-            if (!base.statusLevel) {
-                base.statusLevel = mapStatusLevel(base.status);
-            }
-
-            if (!base.staffingLevel) {
-                base.staffingLevel = mapStatusLevel(base.staffingStatus);
-            }
-
-            if (!Array.isArray(base.assignedStaffIds)) {
-                base.assignedStaffIds = [];
-            }
-
-            return base;
-        });
-
-        const hydratedEmployees = employees.map((employee) => {
-            const base = Object.assign({}, employee);
-            if (!base.statusLevel) {
-                base.statusLevel = mapStatusLevel(base.status);
-            }
-            return base;
-        });
-
-        return {
-            events: hydratedEvents,
-            employees: hydratedEmployees,
-        const normalisedEvents = (Array.isArray(data.events) ? data.events : clone(defaultData.events)).map((event) => {
-            const next = Object.assign({}, event);
-            if (!next.statusLevel && next.status) {
-                next.statusLevel = mapStatusLevel(next.status);
-            }
-            if (!next.staffingLevel && next.staffingStatus) {
-                next.staffingLevel = mapStatusLevel(next.staffingStatus);
-            }
-            if (!Array.isArray(next.assignedTeam)) {
-                next.assignedTeam = [];
-            }
-            return next;
-        });
-
-        const normalisedEmployees = (Array.isArray(data.employees) ? data.employees : clone(defaultData.employees)).map((employee) => {
-            const next = Object.assign({}, employee);
-            if (!next.statusLevel && next.status) {
-                next.statusLevel = mapStatusLevel(next.status);
-            }
-            return next;
-        });
-
-        return {
-            events: normalisedEvents,
-            employees: normalisedEmployees,
-        };
-    }
-
     function generateId(prefix) {
         const randomPart = Math.random().toString(36).slice(2, 8);
         const timePart = Date.now().toString(36);
         return `${prefix}-${randomPart}-${timePart}`;
-    }
-
-    function mapStatusLevel(value) {
-        if (!value) {
-            return 'neutral';
-        }
-
-        const lower = value.toLowerCase();
-        if (lower.includes('unassign')) {
-            return 'danger';
-        }
-
-        if (lower.includes('confirm') || lower.includes('ready') || lower.includes('available') || lower.includes('staffed') || lower.includes('assign')) {
-            return 'success';
-        }
-
-        if (lower.includes('need') || lower.includes('limited') || lower.includes('await') || lower.includes('pto')) {
-            return 'warning';
-        }
-
-        if (lower.includes('overdue') || lower.includes('contract')) {
-            return 'danger';
-        }
-
-        return 'info';
     }
 
     const store = {
@@ -348,61 +608,28 @@
         },
         addEvent(eventInput) {
             const snapshot = readRaw();
-            const event = Object.assign(
-                {
-                    id: generateId('evt'),
-                    createdAt: Date.now(),
-                    assignedStaffIds: [],
-                    requiredStaff: 0,
-                    lastReminderSent: null,
-                },
-                eventInput
-            );
-
-            if (!event.statusLevel) {
-                event.statusLevel = mapStatusLevel(event.status);
-            }
-            if (!event.staffingLevel) {
-                event.staffingLevel = mapStatusLevel(event.staffingStatus);
-            }
-
+            const event = normaliseEvent(Object.assign({ id: generateId('evt'), createdAt: Date.now() }, eventInput));
             snapshot.events.push(event);
             writeRaw(snapshot);
-            return event;
+            return clone(event);
         },
         removeEvent(eventId) {
             const snapshot = readRaw();
-            const nextEvents = snapshot.events.filter((event) => event.id !== eventId);
-            snapshot.events = nextEvents;
+            snapshot.events = snapshot.events.filter((event) => event.id !== eventId);
             writeRaw(snapshot);
         },
         updateEvent(eventId, updates) {
             if (!eventId) {
                 return null;
             }
-
             const snapshot = readRaw();
             const index = snapshot.events.findIndex((event) => event.id === eventId);
-            const snapshot = readRaw();
-            const index = snapshot.events.findIndex((event) => event.id === eventId);
-
             if (index === -1) {
                 return null;
             }
-
             const current = snapshot.events[index];
-            const nextEvent = Object.assign({}, current, updates, {
-                updatedAt: Date.now(),
-            });
-
-            if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
-                nextEvent.statusLevel = mapStatusLevel(nextEvent.status);
-            }
-
-            if (Object.prototype.hasOwnProperty.call(updates, 'staffingStatus')) {
-                nextEvent.staffingLevel = mapStatusLevel(nextEvent.staffingStatus);
-            }
-
+            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
+            const nextEvent = normaliseEvent(Object.assign({}, current, patch, { id: current.id, updatedAt: Date.now() }));
             snapshot.events[index] = nextEvent;
             writeRaw(snapshot);
             return clone(nextEvent);
@@ -414,7 +641,6 @@
             if (index === -1) {
                 return null;
             }
-
             const current = snapshot.events[index];
             const required = typeof current.requiredStaff === 'number' ? current.requiredStaff : 0;
             const assignedCount = ids.length;
@@ -431,27 +657,14 @@
                 staffingStatus = `Assigned ${assignedCount} team`;
             }
 
-            const nextEvent = Object.assign({}, current, {
-                assignedStaffIds: ids,
-                staffingStatus,
-                staffingLevel: mapStatusLevel(staffingStatus),
-                updatedAt: Date.now(),
-            });
-
-            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
-            const nextEvent = Object.assign({}, current, patch);
-
-            if (!nextEvent.statusLevel || (patch && Object.prototype.hasOwnProperty.call(patch, 'status'))) {
-                nextEvent.statusLevel = mapStatusLevel(nextEvent.status);
-            }
-
-            if (!nextEvent.staffingLevel || (patch && (Object.prototype.hasOwnProperty.call(patch, 'staffingStatus') || Object.prototype.hasOwnProperty.call(patch, 'staffingLevel')))) {
-                nextEvent.staffingLevel = mapStatusLevel(nextEvent.staffingStatus);
-            }
-
-            if (!Array.isArray(nextEvent.assignedTeam)) {
-                nextEvent.assignedTeam = [];
-            }
+            const nextEvent = normaliseEvent(
+                Object.assign({}, current, {
+                    assignedStaffIds: ids,
+                    staffingStatus,
+                    staffingLevel: mapStatusLevel(staffingStatus),
+                    updatedAt: Date.now(),
+                })
+            );
 
             snapshot.events[index] = nextEvent;
             writeRaw(snapshot);
@@ -459,32 +672,46 @@
         },
         addEmployee(employeeInput) {
             const snapshot = readRaw();
-            const employee = Object.assign(
-                {
-                    id: generateId('emp'),
-                    createdAt: Date.now(),
-                },
-                employeeInput
+            const employee = normaliseEmployee(
+                Object.assign(
+                    {
+                        id: employeeInput && employeeInput.id ? employeeInput.id : generateId('emp'),
+                        createdAt: Date.now(),
+                    },
+                    employeeInput
+                )
             );
-
-            if (!employee.statusLevel) {
-                employee.statusLevel = mapStatusLevel(employee.status);
-            }
-
             snapshot.employees.push(employee);
             writeRaw(snapshot);
-            return employee;
+            return clone(employee);
+        },
+        updateEmployee(employeeId, updates) {
+            if (!employeeId) {
+                return null;
+            }
+            const snapshot = readRaw();
+            const index = snapshot.employees.findIndex((employee) => employee.id === employeeId);
+            if (index === -1) {
+                return null;
+            }
+            const current = snapshot.employees[index];
+            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
+            const nextEmployee = normaliseEmployee(Object.assign({}, current, patch, { id: current.id, updatedAt: Date.now() }));
+            snapshot.employees[index] = nextEmployee;
+            writeRaw(snapshot);
+            return clone(nextEmployee);
         },
         removeEmployee(employeeId) {
             const snapshot = readRaw();
-            const nextEmployees = snapshot.employees.filter((employee) => employee.id !== employeeId);
-            snapshot.employees = nextEmployees;
+            snapshot.employees = snapshot.employees.filter((employee) => employee.id !== employeeId);
             writeRaw(snapshot);
         },
         clearAll() {
             writeRaw(clone(defaultData));
         },
     };
+
+    writeRaw(readRaw());
 
     global.B2UStore = store;
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add rich default employee records to the shared scheduler store and normalize snapshot helpers
- update the employees page to sync with the store, persisting add/remove and document actions
- refresh the team directory cards, stats, and quick-add form from stored data

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dee435dc908333be20b78a9c4a9d7c