### PR TITLE
Fix storage initialization preventing events and employee data from loading

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -505,7 +505,7 @@
             try {
                 const raw = global.localStorage.getItem(STORAGE_KEY);
                 if (raw) {
-                    cache = normaliseData(JSON.parse(raw));
+                    cache = normalise(JSON.parse(raw));
                     return cache;
                 }
 
@@ -614,11 +614,8 @@
             );
 
             snapshot.events[index] = nextEvent;
-            const patch = typeof updates === 'function' ? updates(clone(current)) : updates;
-            const nextEvent = normaliseEvent(Object.assign({}, current, patch, { updatedAt: Date.now() }));
-            snapshot.events[index] = nextEvent;
             writeRaw(snapshot);
-            return clone(nextEvent.prepSheet);
+            return clone(nextEvent);
         },
         removeEvent(eventId) {
             if (!eventId) {


### PR DESCRIPTION
## Summary
- correct the storage normalisation call so cached data loads without throwing
- clean up updateEvent to avoid duplicate declarations and return the updated event object

## Testing
- node -e "require('./storage.js'); const store = global.B2UStore; console.log('events', store.getEvents().length); console.log('employees', store.getEmployees().length); const firstEvent = store.getEvents()[0]; store.updateEvent(firstEvent.id, { name: 'Updated Event' }); console.log('updated name', store.getEvent(firstEvent.id).name);"

------
https://chatgpt.com/codex/tasks/task_e_68dee8dbc7008333b6867b8eec25a0ef