### PR TITLE
Improve lead modal section formatting

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2141,8 +2141,9 @@ body.modal-open {
 
 .modal-summary {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.6rem 1rem;
+  grid-template-columns: minmax(160px, auto) 1fr;
+  gap: 0.85rem 1.2rem;
+  align-items: start;
 }
 
 @media (max-width: 560px) {
@@ -2152,23 +2153,40 @@ body.modal-open {
 }
 
 .modal-summary dt {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 600;
-  color: var(--slate-400);
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: var(--slate-500);
+  margin: 0;
+  line-height: 1.1;
 }
 
 .modal-summary dd {
+  margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--slate-800);
+  color: var(--slate-900);
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  line-height: 1.45;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .modal-subheading {
-  font-size: 0.95rem;
+  font-size: 0.8rem;
   font-weight: 700;
-  color: var(--slate-700);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--slate-500);
+}
+
+.modal-subheading + * {
+  margin-top: -0.1rem;
 }
 
 .modal-notes {


### PR DESCRIPTION
## Summary
- refine the lead detail modal summary layout to better separate labels from their content
- adjust modal subsection headings so headers are easier to distinguish from body text

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df201823b483338c924c4c969d2978