### PR TITLE
Make lead pipeline detail headers bold

### DIFF
--- a/leads.js
+++ b/leads.js
@@ -221,7 +221,10 @@
         }
 
         const dt = document.createElement('dt');
-        dt.textContent = label;
+        const labelText = document.createElement('strong');
+        labelText.className = 'modal-summary__label';
+        labelText.textContent = label;
+        dt.appendChild(labelText);
 
         const dd = document.createElement('dd');
         if (value instanceof Node) {

--- a/styles.css
+++ b/styles.css
@@ -2198,13 +2198,17 @@ body.modal-open {
 }
 
 .modal-summary dt {
+  margin: 0;
+  line-height: 1.1;
+}
+
+.modal-summary__label {
+  display: block;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-weight: 700;
-  color: var(--slate-500);
-  margin: 0;
-  line-height: 1.1;
+  color: var(--slate-600);
 }
 
 .modal-summary dd {


### PR DESCRIPTION
## Summary
- wrap the lead detail labels in the modal with semantic strong tags to emphasise them
- add styling for the new label element so headers render bold within the lead pipeline detail view

## Testing
- Manual verification: opened the lead detail modal in the browser to confirm headers render bold

------
https://chatgpt.com/codex/tasks/task_e_68e0a2e958d4833390a041827e5d9241