### PR TITLE
Integrate FastAPI events backend and wire UI to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,43 @@ The `pnpm prisma db seed` command populates the SQLite database with sample empl
 3. Click any employee tile (class `.employee-card`) to open the modal.
 4. Refresh the page while the modal is open or navigate to `employees.html?id=<employeeId>` to confirm deep link support.
 5. Use the close button or browser back button to exit the modal and verify the URL updates correctly.
+
+## Events API (FastAPI backend)
+
+The event pipeline now uses a lightweight FastAPI service backed by SQLite. The API automatically creates `events.db` in the
+project root on startup and exposes CRUD endpoints at `http://127.0.0.1:8000/events`.
+
+### Python setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### Running the API locally
+
+```bash
+uvicorn server:app --reload --port 8000
+# or use the npm script
+pnpm run dev:api
+```
+
+Optional environment variables:
+
+- `EVENTS_DB_PATH` – override the SQLite file location (default: `events.db` in the repo root).
+
+### API quick check
+
+```bash
+curl http://127.0.0.1:8000/health
+curl http://127.0.0.1:8000/events
+```
+
+### Tests
+
+```bash
+pytest test_api.py
+```
+
+The tests perform a create → list → update → delete flow and confirm data persists across an app restart.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prisma:generate": "prisma generate --schema server/prisma/schema.prisma",
     "prisma:migrate": "prisma migrate dev --schema server/prisma/schema.prisma",
     "db:seed": "tsx server/prisma/seed.ts",
-    "test:server": "vitest run server/test"
+    "test:server": "vitest run server/test",
+    "dev:api": "uvicorn server:app --reload --port 8000"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.111.0
+uvicorn>=0.30.0
+pytest>=8.0.0

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,84 @@
+"""Integration tests for the FastAPI events backend."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+def test_event_crud_cycle(tmp_path, monkeypatch):
+    """Exercise the full CRUD lifecycle of the events API."""
+
+    db_path = tmp_path / "events.db"
+    monkeypatch.setenv("EVENTS_DB_PATH", str(db_path))
+
+    import server as server_module
+
+    server_module = importlib.reload(server_module)
+
+    sample_event = {
+        "name": "Launch Party",
+        "date": "2025-08-01",
+        "start_time": "18:00",
+        "end_time": "22:00",
+        "location": "Houston Heights",
+        "package": "Premium Mixology",
+        "guest_count": 150,
+        "payout": 4800.0,
+        "target_staff_count": 5,
+        "assign_employees": ["emp-1", "emp-2"],
+        "client_name": "Taylor Morgan",
+        "client_phone": "713-555-0199",
+        "status": "scheduled",
+        "staffing_status": "Fully staffed",
+        "notes": "Include seasonal mocktails",
+    }
+
+    with TestClient(server_module.app) as client:
+        response = client.get("/events")
+        assert response.status_code == 200
+        assert response.json() == []
+
+        response = client.post("/events", json=sample_event)
+        assert response.status_code == 200
+        created = response.json()
+        assert created["name"] == sample_event["name"]
+        assert created["assign_employees"] == sample_event["assign_employees"]
+        event_id = created["id"]
+
+        updated_payload = dict(sample_event)
+        updated_payload.update({
+            "name": "Updated Launch Party",
+            "status": "completed",
+            "payout": 5100.5,
+            "assign_employees": ["emp-1", "emp-3"],
+        })
+
+        response = client.put(f"/events/{event_id}", json=updated_payload)
+        assert response.status_code == 200
+        updated = response.json()
+        assert updated["name"] == "Updated Launch Party"
+        assert updated["status"] == "completed"
+        assert updated["assign_employees"] == ["emp-1", "emp-3"]
+
+    server_module = importlib.reload(server_module)
+
+    with TestClient(server_module.app) as client:
+        response = client.get("/events")
+        assert response.status_code == 200
+        persisted = response.json()
+        assert len(persisted) == 1
+        assert persisted[0]["id"] == event_id
+
+        response = client.delete(f"/events/{event_id}")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+        response = client.get("/events")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    assert Path(db_path).exists()


### PR DESCRIPTION
## Summary
- replace the standalone SQLite helpers with a FastAPI application that initialises the database, enables CORS for the front-end, and adds logging plus a /health endpoint
- add a pytest integration test that exercises create/list/update/delete behaviour while persisting to a temporary database
- update the events UI to call the FastAPI endpoints with graceful local-storage fallback and document the workflow with a new dev:api script and requirements

## Testing
- pytest test_api.py *(skipped: fastapi not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42bee12c483339c3cc5fc6817d164